### PR TITLE
fix(llm): real tool-calling for the keyless local-agent backbone

### DIFF
--- a/src/__tests__/local-agent-tools.test.ts
+++ b/src/__tests__/local-agent-tools.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Text-mode tool calling for the KEYLESS local-agent backbone (Codex / Claude / Hermes).
+ *
+ * Regression for the "operators never execute a single Arsenal tool" defect: the ReAct
+ * AgentLoop drives execution through `chatWithTools(...).toolCalls`, but the CLI-agent
+ * adapters returned text only and silently dropped `options.tools`, so `toolCalls` was
+ * ALWAYS undefined → the loop concluded on iteration 0 and no tool ever fired.
+ *
+ * The fix teaches the CLI-agent adapters a text protocol: describe the tools in the
+ * prompt, and parse a fenced ```tool JSON block back into structured `toolCalls`.
+ * Execution still runs in-process via `arsenal.execute` — the CLI's own sandbox is
+ * irrelevant because we only ask it to PICK the tool, not run it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLocalAgentChat } = vi.hoisted(() => ({ mockLocalAgentChat: vi.fn() }));
+vi.mock('../agent/local-agents.js', () => ({ localAgentChat: mockLocalAgentChat }));
+
+import { LLMBackbone } from '../llm/index.js';
+import type { LLMToolDefinition, LLMMessage, LLMConfig } from '../types/index.js';
+
+const portScan: LLMToolDefinition = {
+  name: 'port_scan',
+  description: 'Scan TCP ports on a target host',
+  parameters: { type: 'object', properties: { target: { type: 'string' } }, required: ['target'] },
+};
+const messages: LLMMessage[] = [{ role: 'user', content: 'Assess 192.168.68.157' }];
+const cfg = (): LLMConfig => ({ provider: 'local-agent', model: 'codex', maxTokens: 4096, temperature: 0.4 });
+
+describe('local-agent backbone — text-mode tool calling', () => {
+  beforeEach(() => mockLocalAgentChat.mockReset());
+
+  it('exposes the tool catalog to the agent (prompt names the callable tools)', async () => {
+    mockLocalAgentChat.mockResolvedValue('done, no tools needed');
+    const llm = new LLMBackbone(cfg());
+    await llm.chatWithTools(messages, [portScan]);
+    const promptSent = String(mockLocalAgentChat.mock.calls[0][1]);
+    expect(promptSent).toContain('port_scan');
+    expect(promptSent).toContain('Scan TCP ports');
+  });
+
+  it('parses a fenced ```tool JSON block into a structured toolCall the ReAct loop can execute', async () => {
+    mockLocalAgentChat.mockResolvedValue(
+      'I will map the reachable services first.\n\n```tool\n{"tool":"port_scan","arguments":{"target":"192.168.68.157"}}\n```'
+    );
+    const llm = new LLMBackbone(cfg());
+    const res = await llm.chatWithTools(messages, [portScan]);
+    expect(res.toolCalls).toBeDefined();
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls![0]).toMatchObject({ name: 'port_scan', arguments: { target: '192.168.68.157' } });
+    expect(res.toolCalls![0].id).toBeTruthy();
+  });
+
+  it('treats a prose reply with no tool block as the final debrief (no toolCalls)', async () => {
+    mockLocalAgentChat.mockResolvedValue('Final debrief: host appears filtered; no vulnerabilities confirmed.');
+    const llm = new LLMBackbone(cfg());
+    const res = await llm.chatWithTools(messages, [portScan]);
+    expect(res.toolCalls).toBeUndefined();
+    expect(res.content).toContain('Final debrief');
+  });
+
+  it('does NOT misread an unrelated JSON object (findings debrief) as a tool call', async () => {
+    mockLocalAgentChat.mockResolvedValue('```json\n{"findings":[],"abstained":true}\n```');
+    const llm = new LLMBackbone(cfg());
+    const res = await llm.chatWithTools(messages, [portScan]);
+    expect(res.toolCalls).toBeUndefined();
+  });
+
+  it('without tools, behaves as a plain text completion (unchanged legacy path)', async () => {
+    mockLocalAgentChat.mockResolvedValue('plain analysis');
+    const llm = new LLMBackbone(cfg());
+    const res = await llm.chat(messages);
+    expect(res.toolCalls).toBeUndefined();
+    expect(res.content).toBe('plain analysis');
+  });
+});

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -777,6 +777,109 @@ class LocalAdapter implements LLMProviderAdapter {
 // CODEX ADAPTER (local Codex CLI/account subscription)
 // =============================================================================
 
+// =============================================================================
+// TEXT-MODE TOOL CALLING (for CLI agents that can't emit structured tool_calls)
+// -----------------------------------------------------------------------------
+// A connected CLI agent (Codex / Claude / Hermes) talks text in, text out — it has
+// no OpenAI/Anthropic-style `tool_calls` channel. The ReAct AgentLoop drives every
+// Arsenal action through `chatWithTools(...).toolCalls`, so without a bridge the loop
+// gets `toolCalls: undefined` on turn 0 and concludes WITHOUT running a single tool.
+//
+// The bridge: describe the tools in the prompt and ask the agent to answer with a
+// fenced ```tool JSON block; parse that back into LLMToolCall[]. Execution still runs
+// in-process via `arsenal.execute`, so the CLI's own read-only sandbox is irrelevant —
+// the agent only PICKS the tool; the harness runs it.
+// =============================================================================
+
+/** Render the callable-tool catalog + the reply protocol into prompt text. */
+export function buildToolProtocol(tools: LLMToolDefinition[]): string {
+  const lines = tools.map(t => {
+    const props = t.parameters?.properties || {};
+    const params = Object.entries(props)
+      .map(([k, v]) => `${k}${t.parameters?.required?.includes(k) ? '' : '?'}: ${v.type}${v.description ? ` — ${v.description}` : ''}`)
+      .join('; ');
+    return `- ${t.name}(${params}): ${t.description}`;
+  });
+  return [
+    '',
+    '## Arsenal tools you can run',
+    'The harness EXECUTES these for you in-process — you are not sandboxed away from them.',
+    'To run one, reply with ONLY a fenced code block tagged `tool` containing a single JSON',
+    'object: {"tool": "<name>", "arguments": { ... }}. Exactly ONE tool call per reply, and no',
+    'prose outside the block. You will receive the tool output and can then call another tool.',
+    'When the assessment is complete and you need no more tools, reply with your final debrief in',
+    'prose (NO tool block), including every finding with its evidence.',
+    '',
+    'Tools:',
+    ...lines,
+  ].join('\n');
+}
+
+/** Balanced-brace scan for top-level JSON objects (no regex on nested braces). */
+function extractJsonObjects(text: string): string[] {
+  const out: string[] = [];
+  let depth = 0, start = -1;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '{') { if (depth === 0) start = i; depth++; }
+    else if (c === '}' && depth > 0) { depth--; if (depth === 0 && start >= 0) { out.push(text.slice(start, i + 1)); start = -1; } }
+  }
+  return out;
+}
+
+/** Coerce one JSON string into a tool call ONLY if it intentfully carries a string "tool" key. */
+function coerceToolCall(raw: string, index: number): LLMToolCall | null {
+  let obj: unknown;
+  try { obj = JSON.parse(raw.trim()); } catch { return null; }
+  if (!obj || typeof obj !== 'object') return null;
+  const rec = obj as Record<string, unknown>;
+  if (typeof rec.tool !== 'string' || !rec.tool.trim()) return null;
+  const args = (rec.arguments ?? rec.args ?? {}) as unknown;
+  return {
+    id: `lac_${index}_${rec.tool}`,
+    name: rec.tool,
+    arguments: args && typeof args === 'object' ? (args as Record<string, unknown>) : {},
+  };
+}
+
+/** Parse an agent's text reply into tool calls: prefer ```tool blocks, then a bare {"tool":...}. */
+export function parseAgentToolCalls(text: string): LLMToolCall[] {
+  if (!text) return [];
+  const calls: LLMToolCall[] = [];
+  const fence = /```tool\s*\n?([\s\S]*?)```/gi;
+  let m: RegExpExecArray | null;
+  while ((m = fence.exec(text)) !== null) {
+    const call = coerceToolCall(m[1], calls.length);
+    if (call) calls.push(call);
+  }
+  if (calls.length) return calls;
+  // Fallback: agent forgot the fence but emitted an intentful {"tool":...} object. Requiring the
+  // "tool" key keeps a plain findings/abstain JSON (no "tool" key) from being misread as a call.
+  for (const block of extractJsonObjects(text)) {
+    const call = coerceToolCall(block, calls.length);
+    if (call) { calls.push(call); break; }
+  }
+  return calls;
+}
+
+/** Strip ```tool blocks so the recorded reasoning content doesn't duplicate the raw call JSON. */
+function stripToolBlocks(text: string): string {
+  return text.replace(/```tool\s*\n?[\s\S]*?```/gi, '').trim();
+}
+
+/** Serialize the ReAct message history for a text-only CLI agent, rendering prior tool
+ *  calls + their results legibly so multi-turn context survives an ephemeral `codex exec`. */
+function renderAgentMessages(messages: LLMMessage[]): string {
+  return messages.map(m => {
+    if (m.role === 'assistant' && m.toolCalls?.length) {
+      const calls = m.toolCalls.map(tc => `${tc.name}(${JSON.stringify(tc.arguments)})`).join(', ');
+      return `\n### ASSISTANT\n${m.content || ''}\n[you called: ${calls}]`;
+    }
+    if (m.role === 'tool') return `\n### TOOL RESULT (${m.name || 'tool'})\n${m.content}`;
+    return `\n### ${m.role.toUpperCase()}\n${m.content}`;
+  }).join('\n');
+}
+
 class CodexAdapter implements LLMProviderAdapter {
   name = 'codex';
   private config: LLMConfig;
@@ -889,18 +992,26 @@ class LocalAgentAdapter implements LLMProviderAdapter {
   }
   private formatPrompt(messages: LLMMessage[], options?: ChatOptions): string {
     const parts = [
-      'You are the local-agent planning brain for T3MP3ST, an authorized offensive-security harness.',
-      'Operate in planning, analysis, and evidence-contract mode. When the caller requests JSON, return ONLY valid JSON or the exact requested fenced block — no preamble.',
+      'You are the local-agent operator brain for T3MP3ST, an authorized offensive-security harness.',
+      'Operate in analysis and evidence-contract mode. When the caller requests JSON, return ONLY valid JSON or the exact requested fenced block — no preamble.',
     ];
     if (options?.maxTokens) parts.push(`Target max output tokens: ${options.maxTokens}.`);
-    for (const m of messages) parts.push(`\n### ${m.role.toUpperCase()}\n${m.content}`);
+    // When tools are offered, expose the catalog + reply protocol so the ReAct loop can
+    // actually drive Arsenal execution instead of degenerating to a single planning turn.
+    if (options?.tools?.length) parts.push(buildToolProtocol(options.tools));
+    parts.push(renderAgentMessages(messages));
     return parts.join('\n');
   }
   async chat(messages: LLMMessage[], options?: ChatOptions): Promise<LLMResponse> {
     const agentId = this.config.model || 'codex';
     const prompt = this.formatPrompt(messages, options);
-    const content = await localAgentChat(agentId, prompt, { timeoutMs: this.config.timeout || 240000 });
-    return { content: content.trim(), model: `local-agent:${agentId}`, finishReason: 'stop' };
+    const raw = (await localAgentChat(agentId, prompt, { timeoutMs: this.config.timeout || 240000 })).trim();
+    const toolCalls = options?.tools?.length ? parseAgentToolCalls(raw) : [];
+    if (toolCalls.length) {
+      // Keep the reasoning (block stripped) as content; the loop records it and re-sends history.
+      return { content: stripToolBlocks(raw) || `Calling ${toolCalls.map(c => c.name).join(', ')}`, model: `local-agent:${agentId}`, toolCalls, finishReason: 'tool_calls' };
+    }
+    return { content: raw, model: `local-agent:${agentId}`, finishReason: 'stop' };
   }
 }
 


### PR DESCRIPTION
Fixes #9.

## What's broken

On the **keyless local-agent backbone** (Codex / Claude / Hermes) the ReAct loop never runs a single Arsenal tool. `LocalAgentAdapter.chat()` drops `options.tools` and never returns `toolCalls`, so `AgentLoop` takes its no-tool branch on iteration 0 (`src/agent/index.ts:214`) and concludes without ever calling `arsenal.execute`. Every operator reasons, then abstains. I watched a 10-operator mission finish `{"findings":[],"abstained":true}` against a live host with 3 open ports.

This is the headline path — "keyless warfare, no API keys." The README says the mission engine is stable keyless (status table) and that every operator "runs the same real, tool-backed ReAct loop as recon." It doesn't, keyless. The benchmarked numbers all ran on API-key backbones (gpt-5.5, Opus 4.8, single-agent) — never the local-agent path where this bug lives. An API-key backbone works fine on the same mission; the defect is specific to local-agent.

## The fix

Give the CLI-agent adapter a text tool-calling channel: put the tool catalog + a reply protocol in the prompt, and parse a fenced ` ```tool ` JSON block back into structured `toolCalls`. Execution stays in-process via `arsenal.execute`, so the CLI agent's read-only sandbox is irrelevant — it only picks the tool; the harness runs it. Multi-turn history is serialized so an ephemeral `codex exec` still sees prior calls and results.

Scoped to `LocalAgentAdapter`. Left `CodexAdapter` (the `codex` provider) alone — its prompt is deliberately planning-only ("Do not run active probes").

## Receipts

- New test `src/__tests__/local-agent-tools.test.ts` (5 cases): catalog exposure, tool-block parsing, prose-is-final, no-misread of a findings JSON, unchanged no-tools path.
- `npm test` → 297/297. `npm run typecheck` clean. `npm run doctor` ok. `npm run field:drill` passed.
- `npm run verify-claims` → **24/24, unchanged** (this touches the adapter, not any bench artifact).
- Real-Codex e2e: with the catalog exposed, Codex emits a valid call in ~22s where the old path abstained —
  ```
  finishReason: tool_calls
  toolCalls: [ { name: "port_scan", arguments: { target: "…", timeout: 1000 } } ]
  ```

## Honest scope

This makes the keyless swarm *able* to execute tools, and Codex followed the protocol cleanly in a single-call e2e. What I did **not** do is benchmark the full multi-turn, 8-archetype swarm end-to-end on the keyless path — protocol adherence across a whole mission is a prompt-tuning question I only spot-checked. So: plumbing fixed and unit+e2e-proven; keyless-swarm reliability is the next thing to earn a number.
