### PR TITLE
Harden egress scope, MCP recon, redaction, and mission/operator robustness

### DIFF
--- a/scripts/verify-claims.mjs
+++ b/scripts/verify-claims.mjs
@@ -60,7 +60,10 @@ for (const f of glob(R('bench/xbow/results'), /^xben_\d+_24\.json$/)) {
   // VERDICT level (graded vs the committed oracle), not the raw-tool-output level. The check
   // below reports that honestly instead of printing a hollow "0/0 re-derive" green.
   const canary = !!r0.canary_hit;
-  const strict = !!v.detected && !canary;
+  // Re-grade against the committed in-artifact oracle: a solve counts only when the reported flag
+  // matches verdict.expected (the ground truth stored beside it), not merely when detected===true.
+  // A hand-edited artifact that flips `detected` without a flag matching `expected` no longer counts.
+  const strict = !!v.detected && !canary && ciMatch(v.reported, v.expected);
   const to = r0.tool_output;
   const coreM = String(v.reported || '').match(/\{([^}\n]{1,512})\}/);
   const core = coreM ? coreM[1] : '';
@@ -134,7 +137,10 @@ console.log('\nCLAIM 2 — Cybench (real 40): hint-free 23/40, 0 fabrications');
 const cf = R('bench/cybench/results/CLEAN40-HINTFREE-aggregate.json');
 if (fs.existsSync(cf)) {
   const d = JSON.parse(fs.readFileSync(cf, 'utf8'));
-  check('Cybench hint-free solved', d.solved === 23, `${d.solved}/40 = ${(100 * d.solved / 40).toFixed(0)}%`);
+  // Recount from the per-task results object rather than trusting the aggregate scalar — a hand-edited
+  // `solved` no longer passes on its own; the count is re-derived from the per-task booleans.
+  const cybRecount = Object.values(d.tasks || {}).filter((t) => t && t.solved === true).length;
+  check('Cybench hint-free solved (recomputed from per-task results)', cybRecount === 23, `${cybRecount}/40 = ${(100 * cybRecount / 40).toFixed(0)}%`);
   check('Cybench tasks attempted = 40 (full real benchmark)', (d.total || Object.keys(d.tasks || {}).length) >= 40, `${d.total || Object.keys(d.tasks || {}).length}`);
 } else check('Cybench aggregate present', false, 'CLEAN40-HINTFREE-aggregate.json missing');
 // scan every cybench solved flag for fabrication

--- a/src/__tests__/arsenal-approval-gate.test.ts
+++ b/src/__tests__/arsenal-approval-gate.test.ts
@@ -71,6 +71,32 @@ describe('Arsenal.execute() — approval gate', () => {
     expect((await ars.execute('httpx_tool', ctx())).success).toBe(true);
     expect(t.ran()).toBe(true);
   });
+
+  it('an UNGATED spicy (credential) built-in still runs but always warns + audits (never silent)', async () => {
+    const ars = new Arsenal();
+    const onWarning = vi.fn();
+    const onDecision = vi.fn();
+    const t = probe('password_spray'); // spicy NAME but no riskTier = the default ungated posture
+    ars.register(t);
+    ars.setApprovalController(new ApprovalController({ onWarning, onDecision }));
+    const res = await ars.execute('password_spray', ctx({ url: 'https://target.example.com/login', username: 'admin' }));
+    expect(res.success).toBe(true); // NOT blocked — default posture preserved
+    expect(t.ran()).toBe(true);
+    expect(onWarning).toHaveBeenCalledTimes(1); // credential is spicy → warned
+    expect(onDecision).toHaveBeenCalledTimes(1);
+    expect(ars.getApprovalController()?.getAudit().some(r => r.tool === 'password_spray' && r.outcome === 'allowed-ungated')).toBe(true);
+  });
+
+  it('an ungated intrusive built-in is audited without a (spicy-only) warning', async () => {
+    const ars = new Arsenal();
+    const onWarning = vi.fn();
+    const t = probe('sqli_scan'); // intrusive tier — audited but not "spicy"
+    ars.register(t);
+    ars.setApprovalController(new ApprovalController({ onWarning }));
+    await ars.execute('sqli_scan', ctx({ url: 'https://target.example.com/?id=1', param: 'id' }));
+    expect(onWarning).not.toHaveBeenCalled();
+    expect(ars.getApprovalController()?.getAudit().some(r => r.tool === 'sqli_scan' && r.outcome === 'allowed-ungated')).toBe(true);
+  });
 });
 
 describe('opt-in built-in gating (T3MP3ST_GATE_BUILTINS) — stampSpicyBuiltin', () => {

--- a/src/__tests__/arsenal-scope-gate.test.ts
+++ b/src/__tests__/arsenal-scope-gate.test.ts
@@ -65,6 +65,18 @@ describe('egress scope gate', () => {
     expect(scopeViolation(s2, ctx({ target: '203.0.113.10' }))).toBeNull(); // the host itself is fine
   });
 
+  it('blocks cloud link-local / metadata (169.254 + IPv6 IMDS) even under allowPrivate, unless explicitly authorized', () => {
+    // implicit private allowance must NEVER reach the IMDS / 169.254.0.0/16 link-local range
+    expect(scopeViolation(scope, ctx({ url: 'http://169.254.169.254/latest/meta-data/iam/' }))).toBe('169.254.169.254');
+    expect(scopeViolation(scope, ctx({ target: '169.254.0.1' }))).toBe('169.254.0.1');
+    expect(scopeViolation(scope, ctx({ url: 'http://[fd00:ec2::254]/latest/meta-data/' }))).toBe('fd00:ec2::254');
+    // a normal RFC1918 private host is still allowed under allowPrivate (zero regression)
+    expect(scopeViolation(scope, ctx({ target: '10.1.2.3' }))).toBeNull();
+    // an operator can still explicitly authorize a metadata host if they really mean to
+    const explicit: ArsenalScope = { allowedHosts: ['169.254.169.254'], allowLoopback: false, allowPrivate: false };
+    expect(scopeViolation(explicit, ctx({ url: 'http://169.254.169.254/x' }))).toBeNull();
+  });
+
   it('no scope set = enforcement off (backward-compat)', () => {
     expect(scopeViolation(null, ctx({ url: 'https://evil.com' }))).toBeNull();
   });

--- a/src/__tests__/cve-lookup.test.ts
+++ b/src/__tests__/cve-lookup.test.ts
@@ -1,0 +1,21 @@
+/**
+ * cve_lookup is a knowledge-base reference tool, not a target probe. The live verification gate
+ * accepts any tool-output evidence, so a cve_lookup finding would be stamped a "verified" critical
+ * attributed to the mission target — reflecting nothing about that target. It must return reference
+ * output only, never a severity-bearing finding.
+ */
+import { describe, it, expect } from 'vitest';
+import { Arsenal, BUILTIN_TOOLS } from '../arsenal/index.js';
+
+describe('cve_lookup', () => {
+  it('returns reference output but emits no target-attributed severity findings', async () => {
+    const ars = new Arsenal();
+    ars.registerMany(BUILTIN_TOOLS);
+    // "cve" matches every entry id; the DB contains several CVSS>=9.0 rows that previously minted a
+    // "Critical CVEs Found" finding.
+    const res = await ars.execute('cve_lookup', { parameters: { query: 'cve' } });
+    expect(res.success).toBe(true);
+    expect(res.output).toContain('CVE');
+    expect(res.findings ?? []).toHaveLength(0);
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -441,6 +441,24 @@ describe('Wedged-dispatch timeout backstop', () => {
   }, 15000);
 });
 
+describe('Egress scope derivation from mission targets', () => {
+  it('a public-only mission leaves loopback + private ranges OUT of implicit scope', async () => {
+    const { TempestCommand } = await import('../index.js');
+    const command = new TempestCommand({ name: 'Scope Op', llm: { provider: 'mock', model: 'mock-model' } });
+    command.targetEnv.addTarget({ name: 'shop', address: 'shop.example.com', type: 'web_application', zone: 'external' });
+    const scope = command.arsenal.getScope();
+    expect(scope).toMatchObject({ allowLoopback: false, allowPrivate: false });
+    expect(scope?.allowedHosts).toContain('shop.example.com');
+  });
+
+  it('admits private ranges only when the mission explicitly targets one', async () => {
+    const { TempestCommand } = await import('../index.js');
+    const command = new TempestCommand({ name: 'Lab Op', llm: { provider: 'mock', model: 'mock-model' } });
+    command.targetEnv.addTarget({ name: 'lab', address: '10.0.0.5', type: 'host', zone: 'internal' });
+    expect(command.arsenal.getScope()).toMatchObject({ allowPrivate: true });
+  });
+});
+
 describe('Codex account provider', () => {
   it('should expose Codex as an API-keyless planning backend', () => {
     const llm = new LLMBackbone({

--- a/src/__tests__/mcp-guards.test.ts
+++ b/src/__tests__/mcp-guards.test.ts
@@ -1,0 +1,53 @@
+/**
+ * MCP recon authorization guards. The MCP plane is a standalone stdio process with no mission scope,
+ * so it must enforce parity with the HTTP recon endpoint: local/lab targets free, public targets behind
+ * an operator allowlist, and option-looking ("-…") targets rejected before reaching nmap's argv.
+ */
+import { describe, it, expect } from 'vitest';
+import { validMcpTarget, isLocalLabTarget, mcpTargetDecision } from '../mcp-guards.js';
+
+describe('validMcpTarget', () => {
+  it('accepts hostnames and IPv4/IPv6 literals', () => {
+    expect(validMcpTarget('scanme.nmap.org')).toBe(true);
+    expect(validMcpTarget('10.0.0.5')).toBe(true);
+    expect(validMcpTarget('::1')).toBe(true);
+    expect(validMcpTarget('::ffff:1.2.3.4')).toBe(true);
+  });
+  it('rejects option-looking leading-dash targets (nmap flag smuggling)', () => {
+    expect(validMcpTarget('-oNx')).toBe(false);
+    expect(validMcpTarget('-iLwordlist')).toBe(false);
+  });
+  it('rejects shell metacharacters and non-strings', () => {
+    expect(validMcpTarget('evil.com; id')).toBe(false);
+    expect(validMcpTarget(42)).toBe(false);
+  });
+});
+
+describe('mcpTargetDecision', () => {
+  it('allows local/lab targets with no allowlist', () => {
+    expect(mcpTargetDecision('127.0.0.1', []).allowed).toBe(true);
+    expect(mcpTargetDecision('localhost', []).allowed).toBe(true);
+    expect(mcpTargetDecision('10.0.0.5', []).allowed).toBe(true);
+    expect(mcpTargetDecision('::1', []).allowed).toBe(true);
+  });
+  it('denies an unlisted public target', () => {
+    expect(mcpTargetDecision('8.8.8.8', []).allowed).toBe(false);
+    expect(mcpTargetDecision('scanme.nmap.org', []).allowed).toBe(false);
+  });
+  it('allows a public target listed exactly or as a subdomain', () => {
+    expect(mcpTargetDecision('scanme.nmap.org', ['nmap.org']).allowed).toBe(true);
+    expect(mcpTargetDecision('8.8.8.8', ['8.8.8.8']).allowed).toBe(true);
+  });
+  it('denies a leading-dash target regardless of allowlist', () => {
+    expect(mcpTargetDecision('-oNx', ['nmap.org']).allowed).toBe(false);
+  });
+});
+
+describe('isLocalLabTarget', () => {
+  it('classifies loopback/RFC1918/link-local as lab', () => {
+    expect(isLocalLabTarget('127.0.0.1')).toBe(true);
+    expect(isLocalLabTarget('192.168.1.10')).toBe(true);
+    expect(isLocalLabTarget('169.254.169.254')).toBe(true);
+    expect(isLocalLabTarget('8.8.8.8')).toBe(false);
+  });
+});

--- a/src/__tests__/mission-routing.test.ts
+++ b/src/__tests__/mission-routing.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tasks are routed to targets by an explicit target address, not by substring-matching the free-text
+ * description. Two targets where one address is a prefix of another (10.0.0.1 vs 10.0.0.10 — universal
+ * in a /24 sweep) must each be fully seeded and not conflated.
+ */
+import { describe, it, expect } from 'vitest';
+import { MissionControl } from '../mission/index.js';
+
+describe('multi-target task seeding (prefix-collision safety)', () => {
+  it('seeds tasks for a target whose address is a prefix of an already-seeded target', () => {
+    const mc = new MissionControl();
+    const m = mc.createMission({ name: 'Sweep', description: 'x', objectives: ['enumerate'] });
+    mc.startMission(m.id);
+
+    mc.generateTasksForTarget('10.0.0.10');
+    mc.generateTasksForTarget('10.0.0.1'); // prefix of 10.0.0.10 — must NOT be deduped away
+
+    const tasks = mc.getTaskQueue()!.getForMission(m.id);
+    expect(tasks.some(t => t.targetAddress === '10.0.0.10')).toBe(true);
+    expect(tasks.some(t => t.targetAddress === '10.0.0.1')).toBe(true);
+  });
+});

--- a/src/__tests__/operator-lifecycle.test.ts
+++ b/src/__tests__/operator-lifecycle.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Operator lifecycle races. Two independent defects both stem from a tracked async promise whose late
+ * settle mutates shared operator state:
+ *  - a cleared cooldown must still settle its awaiting assignTask (no leaked pending promise), and
+ *  - a dispatch reaped by the backstop must not, when it finally settles, corrupt the operator that has
+ *    since been re-dispatched a new task.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createOperator } from '../operators/index.js';
+import { LLMBackbone } from '../llm/index.js';
+import { Arsenal } from '../arsenal/index.js';
+import type { AgentLoop } from '../agent/index.js';
+import type { AgentResult } from '../agent/index.js';
+
+const CFG = { maxDetectionRisk: 0.8, cooldownMs: 100_000, maxRetries: 0, preferredTechniques: [], avoidTechniques: [], toolPreferences: [] };
+const llm = () => new LLMBackbone({ provider: 'mock', model: 'mock-model' });
+const okResult: AgentResult = { success: true, summary: 'ok', steps: [], findings: [], iterations: 1, tokensUsed: 0, durationMs: 0, hitLimit: false };
+const fastLoop = () => ({ run: async () => okResult } as unknown as AgentLoop);
+const task = (id: string) => ({ id, missionId: 'm', name: 'r', description: 'scan x', phase: 'reconnaissance', operatorType: 'recon', status: 'pending', priority: 1, dependencies: [], createdAt: 1 } as any);
+
+describe('operator cooldown-resolve (no leaked promise)', () => {
+  it('abortActiveTask settles a parked cooldown so assignTask resolves instead of hanging', async () => {
+    const op = createOperator('Cool-1', 'recon', CFG, llm());
+    op.attachArsenal(new Arsenal(), fastLoop());
+    const p = op.assignTask(task('A')); // executes fast, then parks on the 100s cooldown timer
+    await vi.waitFor(() => expect(op.status).toBe('cooldown'), { timeout: 1000 });
+    op.abortActiveTask('interrupt'); // clears the timer — must also settle the awaiting promise
+    await expect(p).resolves.toMatchObject({ success: true });
+  });
+});
+
+describe('operator dispatch-epoch guard (late-settle race)', () => {
+  it('a reaped dispatch that settles late does not double-count or corrupt the re-dispatched task', async () => {
+    const op = createOperator('Race-1', 'recon', CFG, llm());
+    // A slow loop we resolve on demand — simulates a task still running when the backstop reaps it.
+    let release!: () => void;
+    const slowLoop = { run: () => new Promise<AgentResult>((res) => { release = () => res(okResult); }) } as unknown as AgentLoop;
+    op.attachArsenal(new Arsenal(), slowLoop);
+
+    const pA = op.assignTask(task('A'));
+    await vi.waitFor(() => expect(op.status).toBe('executing'), { timeout: 1000 });
+
+    op.abortActiveTask('timeout'); // backstop reaps A: operator idle, dispatch epoch bumped
+    expect(op.state.completedTasks).toBe(0);
+
+    // Re-dispatch a NEW task B to the now-idle operator, which completes normally.
+    op.attachArsenal(new Arsenal(), fastLoop());
+    void op.assignTask(task('B'));
+    await vi.waitFor(() => expect(op.status).toBe('cooldown'), { timeout: 1000 }); // B did its work
+    expect(op.state.completedTasks).toBe(1); // B counted once
+
+    // Now let A's original promise settle LATE. It must skip its shared-state mutations.
+    release();
+    await pA;
+    expect(op.state.completedTasks).toBe(1); // A did NOT double-count
+  });
+});

--- a/src/__tests__/path-guard.test.ts
+++ b/src/__tests__/path-guard.test.ts
@@ -1,0 +1,36 @@
+/**
+ * File-path guard for the fuzz/credential tools. A wordlist/user/pass-list path is LLM-controlled and
+ * its lines are sent to the (in-scope, possibly adversarial) target, so pointing one at a key/credential
+ * file would exfiltrate it. isSensitiveFilePath denies the high-value secrets while leaving ordinary
+ * wordlists untouched. Pure (home injectable).
+ */
+import { describe, it, expect } from 'vitest';
+import { isSensitiveFilePath } from '../arsenal/path-guard.js';
+
+const HOME = '/home/op';
+
+describe('isSensitiveFilePath', () => {
+  it('denies secret dotdirs under home (~ and absolute)', () => {
+    expect(isSensitiveFilePath('~/.ssh/id_rsa', HOME)).toBe(true);
+    expect(isSensitiveFilePath('/home/op/.aws/credentials', HOME)).toBe(true);
+    expect(isSensitiveFilePath('~/.gnupg/secring.gpg', HOME)).toBe(true);
+    expect(isSensitiveFilePath('~/.config/gh/hosts.yml', HOME)).toBe(true);
+  });
+
+  it('denies system credential stores and key files anywhere', () => {
+    expect(isSensitiveFilePath('/etc/shadow', HOME)).toBe(true);
+    expect(isSensitiveFilePath('/opt/certs/server.pem', HOME)).toBe(true);
+    expect(isSensitiveFilePath('/tmp/id_ed25519', HOME)).toBe(true);
+  });
+
+  it('denies a traversal that resolves into a secret dir', () => {
+    expect(isSensitiveFilePath('/home/op/lists/../.ssh/id_rsa', HOME)).toBe(true);
+  });
+
+  it('allows ordinary wordlists', () => {
+    expect(isSensitiveFilePath('/usr/share/wordlists/dirb/common.txt', HOME)).toBe(false);
+    expect(isSensitiveFilePath('~/seclists/Discovery/Web-Content/common.txt', HOME)).toBe(false);
+    expect(isSensitiveFilePath('common', HOME)).toBe(false);
+    expect(isSensitiveFilePath(undefined, HOME)).toBe(false);
+  });
+});

--- a/src/__tests__/redact.test.ts
+++ b/src/__tests__/redact.test.ts
@@ -32,6 +32,22 @@ describe('redactString — URL userinfo (basic-auth) scrub', () => {
   });
 });
 
+describe('redactString — hashes must survive redaction (no over-redaction)', () => {
+  it('does NOT corrupt a 40-hex SHA-1 / git commit SHA', () => {
+    const sha1 = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
+    expect(redactString(`checksum ${sha1} ok`)).toBe(`checksum ${sha1} ok`);
+  });
+
+  it('does NOT corrupt a 64-hex SHA-256', () => {
+    const sha256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    expect(redactString(`digest ${sha256}`)).toBe(`digest ${sha256}`);
+  });
+
+  it('still redacts a genuine mixed-case AWS secret key (base64 with / )', () => {
+    expect(redactString('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')).toBe('[redacted]');
+  });
+});
+
 describe('redactSecrets — approval-audit record shape', () => {
   it('scrubs a userinfo password in the audit target/action a gated credential tool would record', () => {
     // mirrors what Arsenal.execute() records for password_spray({ url: 'https://user:pass@host/login' })

--- a/src/__tests__/scoped-fetch.test.ts
+++ b/src/__tests__/scoped-fetch.test.ts
@@ -1,0 +1,42 @@
+/**
+ * scopedFetch redirect revalidation — the egress scope gate validates only the INITIAL host, so a
+ * hostile in-scope target that 30x-es the request must not carry the tool to an off-scope host.
+ * resolveScopedRedirect is the pure hop-decision; these pins cover the same-host follow (zero
+ * regression) and the cross-host block.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveScopedRedirect, type ArsenalScope } from '../arsenal/index.js';
+
+const scope: ArsenalScope = { allowedHosts: ['shop.example.com'], allowLoopback: false, allowPrivate: false };
+
+describe('resolveScopedRedirect', () => {
+  it('follows a same-host http->https redirect (zero regression)', () => {
+    const r = resolveScopedRedirect(scope, 'http://shop.example.com/', 'https://shop.example.com/');
+    expect(r).toEqual({ url: 'https://shop.example.com/' });
+  });
+
+  it('follows a same-host trailing-slash / relative redirect', () => {
+    const r = resolveScopedRedirect(scope, 'https://shop.example.com/login', '/dashboard');
+    expect(r).toEqual({ url: 'https://shop.example.com/dashboard' });
+  });
+
+  it('follows a redirect to an authorized subdomain', () => {
+    const r = resolveScopedRedirect(scope, 'https://shop.example.com/', 'https://api.shop.example.com/v1');
+    expect(r).toEqual({ url: 'https://api.shop.example.com/v1' });
+  });
+
+  it('BLOCKS a cross-host redirect to an off-scope public host', () => {
+    const r = resolveScopedRedirect(scope, 'https://shop.example.com/', 'https://attacker-exfil.com/leak');
+    expect(r).toEqual({ blocked: 'attacker-exfil.com' });
+  });
+
+  it('BLOCKS a redirect to cloud metadata even from an in-scope origin', () => {
+    const r = resolveScopedRedirect(scope, 'https://shop.example.com/', 'http://169.254.169.254/latest/meta-data/');
+    expect(r).toEqual({ blocked: '169.254.169.254' });
+  });
+
+  it('null scope = enforcement off, always follows (library/back-compat)', () => {
+    const r = resolveScopedRedirect(null, 'https://shop.example.com/', 'https://anywhere.example.net/');
+    expect(r).toEqual({ url: 'https://anywhere.example.net/' });
+  });
+});

--- a/src/__tests__/whois-server.test.ts
+++ b/src/__tests__/whois-server.test.ts
@@ -1,0 +1,32 @@
+/**
+ * whois_lookup registry egress. The scope gate validates the `domain` param but the handler opens a
+ * socket to a TLD-derived registry server the gate never sees. Registry egress is protocol
+ * infrastructure (not scope-checked), but a model controls the domain — so an unknown/malformed TLD
+ * must resolve to null (clean error) instead of a blind connect to an arbitrary whois.nic.<x> host.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveWhoisServer } from '../arsenal/index.js';
+
+const map: Record<string, string> = { com: 'whois.verisign-grs.com', io: 'whois.nic.io' };
+
+describe('resolveWhoisServer', () => {
+  it('uses the known-registry map first', () => {
+    expect(resolveWhoisServer('com', map)).toBe('whois.verisign-grs.com');
+  });
+
+  it('falls back to the IANA-convention whois.nic.<tld> for a well-formed gTLD/ccTLD', () => {
+    expect(resolveWhoisServer('xyz', map)).toBe('whois.nic.xyz');
+    expect(resolveWhoisServer('shop', map)).toBe('whois.nic.shop');
+  });
+
+  it('resolves a punycode IDN TLD', () => {
+    expect(resolveWhoisServer('xn--p1ai', map)).toBe('whois.nic.xn--p1ai');
+  });
+
+  it('returns null for an unsupported / malformed TLD instead of a blind connect', () => {
+    expect(resolveWhoisServer('', map)).toBeNull();
+    expect(resolveWhoisServer('123', map)).toBeNull();
+    expect(resolveWhoisServer('a b', map)).toBeNull();
+    expect(resolveWhoisServer('evil-injection.attacker', map)).toBeNull();
+  });
+});

--- a/src/arsenal/adapter-tools.ts
+++ b/src/arsenal/adapter-tools.ts
@@ -25,6 +25,7 @@
 
 import type { ToolAdapter } from './catalog.js';
 import type { CustomTool, ToolContext, ToolResult } from '../types/index.js';
+import { isSensitiveFilePath } from './path-guard.js';
 
 // =============================================================================
 // INJECTED DEPENDENCIES
@@ -120,6 +121,7 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     build: (target, params) => {
       const wordlist = str(params.wordlist) ?? '/usr/share/wordlists/dirb/common.txt';
       const mc = str(params.mc) ?? '200,301,302,403';
+      if (isSensitiveFilePath(wordlist)) throw new Error(`wordlist '${wordlist}' resolves to sensitive local material (keys/credentials) — refused (its lines would be sent to the target)`);
       return ['-u', target, '-w', wordlist, '-mc', mc, '-o', '/dev/stdout', '-of', 'json', '-s'];
     },
   },
@@ -139,6 +141,7 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     build: (target, params) => {
       const mode = str(params.mode) ?? 'dir';
       const wordlist = str(params.wordlist) ?? '/usr/share/wordlists/dirb/common.txt';
+      if (isSensitiveFilePath(wordlist)) throw new Error(`wordlist '${wordlist}' resolves to sensitive local material (keys/credentials) — refused (its lines would be sent to the target)`);
       return [mode, '-u', target, '-w', wordlist, '-q'];
     },
   },

--- a/src/arsenal/approval.ts
+++ b/src/arsenal/approval.ts
@@ -70,6 +70,7 @@ export interface ApprovalRequest {
 export type ApprovalOutcome =
   | 'allowed-preapproved' // already on the allowlist or approved earlier this session
   | 'allowed-interactive' // the operator said yes just now (and the tool is now free)
+  | 'allowed-ungated' // an ungated spicy built-in that ran without a gate but is warned + audited
   | 'denied-declined' // the operator said no
   | 'denied-no-approver'; // fail-safe: gated, not approved, and no approver was wired
 
@@ -126,6 +127,20 @@ export class ApprovalController {
   /** Approve a tool for the rest of the session ("approve once, then free"). */
   approveTool(name: string): void {
     this.approved.add(name);
+  }
+
+  /**
+   * Record + surface an UNGATED spicy built-in call. Such tools (the default-posture credential /
+   * intrusive probes) are NOT blocked — they still run — but a live credential or injection probe must
+   * never fire silently: this always lands the call in the audit trail and, for a spicy tier, fires the
+   * non-blocking warning. Distinct from gate(): no allow/deny decision, only visibility.
+   */
+  noteUngated(req: ApprovalRequest): void {
+    const spicy = isSpicyRisk(req.risk);
+    if (spicy && this.policy.onWarning) this.policy.onWarning(req);
+    const rec: ApprovalRecord = { ...req, outcome: 'allowed-ungated', spicy, at: this.now() };
+    this.audit.push(rec);
+    this.policy.onDecision?.(rec);
   }
 
   /** Is this tool currently approved (via the allowlist or an earlier interactive yes)? */

--- a/src/arsenal/index.ts
+++ b/src/arsenal/index.ts
@@ -12,6 +12,7 @@ import * as net from 'net';
 import * as dns from 'dns';
 import * as tls from 'tls';
 import { ApprovalController, isGatedRisk, type ApprovalRequest } from './approval.js';
+import { isSensitiveFilePath } from './path-guard.js';
 
 const execFileAsync = promisify(execFile);
 import type {
@@ -112,15 +113,24 @@ export function hostFromTargetValue(v: unknown): string | null {
   return s.toLowerCase() || null;
 }
 
-function isLoopbackTargetHost(h: string): boolean {
+export function isLoopbackTargetHost(h: string): boolean {
   return h === 'localhost' || h === '::1' || /^127(?:\.\d{1,3}){3}$/.test(h);
 }
-function isPrivateTargetHost(h: string): boolean {
+export function isPrivateTargetHost(h: string): boolean {
   return /^10(?:\.\d{1,3}){3}$/.test(h)
     || /^192\.168(?:\.\d{1,3}){2}$/.test(h)
     || /^172\.(1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}$/.test(h)
     || /^169\.254(?:\.\d{1,3}){2}$/.test(h)          // link-local
     || /^(fc|fd)[0-9a-f]{2}:/i.test(h);              // IPv6 ULA
+}
+
+/** Cloud link-local / instance-metadata endpoints (IMDS). Never a legitimate IMPLICIT lab target —
+ *  AWS/GCP/Azure all serve credentials at 169.254.169.254, and the whole 169.254.0.0/16 link-local
+ *  block plus the IPv6 IMDS address are refused on the implicit-private path even under allowPrivate.
+ *  An operator who genuinely means to reach one must add it to allowedHosts explicitly. */
+export function isMetadataOrLinkLocalHost(h: string): boolean {
+  return /^169\.254(?:\.\d{1,3}){2}$/.test(h)   // 169.254.0.0/16 link-local (incl. IMDS 169.254.169.254)
+    || h === 'fd00:ec2::254';                    // AWS IMDSv6
 }
 
 /** The narrowest CIDR prefix that keeps a private/loopback host's whole block in scope — a wider
@@ -159,9 +169,11 @@ export function scopeViolation(scope: ArsenalScope | null, context: ToolContext)
     // sweep the entire internet past a scope authorizing only that base. Validate the range, not the
     // base. (adversarial-review CIDR mask-strip escape)
     let minMask: number;
-    if (scope.allowLoopback && isLoopbackTargetHost(h)) minMask = 8;              // 127/8, ::1
-    else if (scope.allowPrivate && isPrivateTargetHost(h)) minMask = privateBlockMinMask(h);
-    else if (allow.some(a => a === h || h.endsWith('.' + a))) minMask = 32;        // exact-allowed host → only /32
+    if (allow.some(a => a === h || h.endsWith('.' + a))) minMask = 32;             // exact-allowed host → only /32
+    else if (scope.allowLoopback && isLoopbackTargetHost(h)) minMask = 8;          // 127/8, ::1
+    // implicit private allowance never reaches IMDS / link-local — an explicit allowlist entry above
+    // is the only way in (checked first), so a metadata host that isn't authorized falls through to deny.
+    else if (scope.allowPrivate && isPrivateTargetHost(h) && !isMetadataOrLinkLocalHost(h)) minMask = privateBlockMinMask(h);
     else return h; // base host out of scope
     // treat a trailing "/N" as a CIDR mask ONLY on a bare host/ip (no scheme) — not a URL path segment.
     const cidr = !v.includes('://') && v.match(/^[^/]+\/(\d{1,3})$/);
@@ -191,6 +203,72 @@ function describeToolAction(toolName: string, context: ToolContext): string {
     .join(' ');
   const target = approvalTargetOf(context);
   return `${toolName}${summary ? ` (${summary})` : ''}${target ? ` → ${target}` : ''}`;
+}
+
+/** Max redirect hops scopedFetch follows before giving up (undici's default is 20; capped lower). */
+const SCOPED_FETCH_MAX_REDIRECTS = 10;
+
+/** Thrown by scopedFetch when a redirect points at a host outside the authorized egress scope. */
+export class ScopeRedirectError extends Error {}
+
+/**
+ * Decide a single redirect hop: resolve the `Location` against the current URL and re-validate the
+ * destination host against the SAME egress scope the initial request already passed. Returns the
+ * absolute next URL when in scope, or `{ blocked }` naming the out-of-scope host. `scope == null`
+ * (enforcement off / library mode) always allows — preserving the legacy follow behavior. Pure.
+ */
+export function resolveScopedRedirect(
+  scope: ArsenalScope | null | undefined,
+  currentUrl: string,
+  location: string,
+): { url: string } | { blocked: string } {
+  const next = new URL(location, currentUrl).toString();
+  const violation = scopeViolation(scope ?? null, { parameters: { url: next } });
+  return violation ? { blocked: violation } : { url: next };
+}
+
+/**
+ * fetch() that re-validates every redirect hop against the egress scope. The initial host is already
+ * gated by Arsenal.execute(); this closes the redirect bypass where an in-scope target 30x-es the
+ * request to an off-scope host and the tool transparently follows. Same-host http→https / trailing-
+ * slash redirects re-validate to the same in-scope host and are followed normally (zero regression);
+ * a cross-host off-scope hop throws ScopeRedirectError (surfaced by the handler's existing try/catch).
+ */
+export async function scopedFetch(
+  url: string,
+  scope: ArsenalScope | null | undefined,
+  init?: RequestInit,
+): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= SCOPED_FETCH_MAX_REDIRECTS; hop++) {
+    const resp = await fetch(current, { ...init, redirect: 'manual' });
+    const location = resp.status >= 300 && resp.status < 400 ? resp.headers.get('location') : null;
+    if (!location) return resp;
+    const decision = resolveScopedRedirect(scope, current, location);
+    if ('blocked' in decision) {
+      throw new ScopeRedirectError(
+        `SCOPE DENIED: redirect to '${decision.blocked}' is outside the authorized scope — not followed.`,
+      );
+    }
+    current = decision.url;
+  }
+  throw new ScopeRedirectError(`too many redirects (> ${SCOPED_FETCH_MAX_REDIRECTS})`);
+}
+
+/**
+ * Resolve the authoritative WHOIS server for a TLD. Registry egress is protocol-mandated
+ * infrastructure (like a DNS resolver), so it is intentionally NOT scope-checked against the target
+ * allowlist — the registry is by definition never the target. But a model controls the domain (hence
+ * the derived server), so an unknown/malformed TLD returns null and the handler reports a clean
+ * "unsupported TLD" error instead of blindly connecting to an arbitrary whois.nic.<x> host. The
+ * IANA-convention whois.nic.<tld> covers the many gTLDs/ccTLDs not in the hardcoded map.
+ */
+export function resolveWhoisServer(tld: string, servers: Record<string, string>): string | null {
+  if (servers[tld]) return servers[tld];
+  // Only a well-formed TLD becomes a whois.nic.<tld> connect: ASCII letters (2–24) or a punycode IDN
+  // TLD (xn--…). Anything else is not a registry TLD and must not be turned into a blind connect.
+  if (/^[a-z]{2,24}$/.test(tld) || /^xn--[a-z0-9]{2,59}$/.test(tld)) return `whois.nic.${tld}`;
+  return null;
 }
 
 export class Arsenal extends EventEmitter<ArsenalEvents> {
@@ -289,7 +367,26 @@ export class Arsenal extends EventEmitter<ArsenalEvents> {
         this.emit('tool:error', { tool, error: new Error(denied.error) });
         return denied;
       }
+    } else if (SPICY_BUILTIN_TIERS[toolName] && !isGatedRisk(tool.riskTier)) {
+      // An ungated spicy built-in (the default posture for password_spray / sqli_scan / xss_scan /
+      // hash_crack) is NOT blocked, but a live credential / injection probe must never fire silently:
+      // always warn + audit so the action is seen even when the approval fail-safe doesn't fence it.
+      // Opting in with T3MP3ST_GATE_BUILTINS=1 stamps a riskTier and routes it through the gate above.
+      const request: ApprovalRequest = {
+        tool: toolName,
+        risk: SPICY_BUILTIN_TIERS[toolName],
+        operator: context.operator,
+        target: approvalTargetOf(context),
+        action: describeToolAction(toolName, context),
+      };
+      if (this.approval) this.approval.noteUngated(request);
+      // eslint-disable-next-line no-console
+      else console.warn(`⚠️  SPICY ACTION [${request.risk}] ${request.operator ? request.operator + ' → ' : ''}${request.action}`);
     }
+
+    // Expose the active egress scope to scope-aware handlers (scopedFetch) so they can re-validate
+    // redirect hops against the same allowlist the initial host already passed.
+    context.scope = this.scope;
 
     const execution: ToolExecution = {
       id: randomUUID(),
@@ -660,7 +757,13 @@ export const BUILTIN_TOOLS: CustomTool[] = [
         'au': 'whois.auda.org.au',
       };
 
-      const whoisServer = whoisServers[tld] || `whois.nic.${tld}`;
+      const whoisServer = resolveWhoisServer(tld, whoisServers);
+      if (!whoisServer) {
+        return {
+          success: false,
+          error: `Unsupported or malformed TLD '.${tld}' — no known WHOIS registry server; refusing to connect to an arbitrary host.`,
+        };
+      }
 
       return new Promise((resolve) => {
         const socket = new net.Socket();
@@ -752,7 +855,7 @@ export const BUILTIN_TOOLS: CustomTool[] = [
       const body = context.parameters.body as string | undefined;
 
       try {
-        const response = await fetch(url, {
+        const response = await scopedFetch(url, context.scope, {
           method,
           headers,
           body: body && method !== 'GET' ? body : undefined,
@@ -787,7 +890,7 @@ export const BUILTIN_TOOLS: CustomTool[] = [
         'Permissions-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy',
       ];
       try {
-        const response = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(10000) });
+        const response = await scopedFetch(url, context.scope, { method: 'HEAD', signal: AbortSignal.timeout(10000) });
         const analysis = securityHeaders.map(h => {
           const value = response.headers.get(h);
           return `${h}: ${value ? `✓ ${value}` : '✗ Missing'}`;
@@ -895,7 +998,7 @@ export const BUILTIN_TOOLS: CustomTool[] = [
       const url = context.parameters.url as string;
 
       try {
-        const response = await fetch(url, {
+        const response = await scopedFetch(url, context.scope, {
           signal: AbortSignal.timeout(10000),
         });
 
@@ -1022,7 +1125,7 @@ export const BUILTIN_TOOLS: CustomTool[] = [
           const testUrl = new URL(baseUrl);
           testUrl.searchParams.set(param, payload);
 
-          const response = await fetch(testUrl.toString(), {
+          const response = await scopedFetch(testUrl.toString(), context.scope, {
             signal: AbortSignal.timeout(5000),
           });
           const body = await response.text();
@@ -1099,7 +1202,7 @@ export const BUILTIN_TOOLS: CustomTool[] = [
       try {
         const baselineUrl = new URL(baseUrl);
         baselineUrl.searchParams.set(param, 'normalvalue');
-        const baselineResp = await fetch(baselineUrl.toString(), { signal: AbortSignal.timeout(5000) });
+        const baselineResp = await scopedFetch(baselineUrl.toString(), context.scope, { signal: AbortSignal.timeout(5000) });
         const baselineBody = await baselineResp.text();
         baselineLength = baselineBody.length;
       } catch {
@@ -1111,7 +1214,7 @@ export const BUILTIN_TOOLS: CustomTool[] = [
           const testUrl = new URL(baseUrl);
           testUrl.searchParams.set(param, payload);
 
-          const response = await fetch(testUrl.toString(), { signal: AbortSignal.timeout(5000) });
+          const response = await scopedFetch(testUrl.toString(), context.scope, { signal: AbortSignal.timeout(5000) });
           const body = await response.text();
           const bodyLower = body.toLowerCase();
 
@@ -1605,7 +1708,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
 
       try {
         const robotsUrl = `${baseUrl}/robots.txt`;
-        const response = await fetch(robotsUrl, {
+        const response = await scopedFetch(robotsUrl, context.scope, {
           signal: AbortSignal.timeout(10000),
         });
 
@@ -1766,7 +1869,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
 
       try {
         // Fetch main page
-        const response = await fetch(url, {
+        const response = await scopedFetch(url, context.scope, {
           signal: AbortSignal.timeout(10000),
         });
         const headers = Object.fromEntries(response.headers.entries());
@@ -1994,7 +2097,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
       const url = context.parameters.url as string;
 
       try {
-        const response = await fetch(url, {
+        const response = await scopedFetch(url, context.scope, {
           method: 'GET',
           signal: AbortSignal.timeout(10000),
         });
@@ -2231,7 +2334,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
       // First try OPTIONS to see if Allow header is returned
       let optionsAllow: string | null = null;
       try {
-        const optResp = await fetch(url, {
+        const optResp = await scopedFetch(url, context.scope, {
           method: 'OPTIONS',
           signal: AbortSignal.timeout(5000),
         });
@@ -2332,7 +2435,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
 
       for (const test of testOrigins) {
         try {
-          const response = await fetch(url, {
+          const response = await scopedFetch(url, context.scope, {
             method: 'GET',
             headers: { 'Origin': test.origin },
             signal: AbortSignal.timeout(5000),
@@ -2613,7 +2716,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
       try {
         const baselineUrl = new URL(baseUrl);
         baselineUrl.searchParams.set(param, 'nonexistent_file_xyz');
-        const baseResp = await fetch(baselineUrl.toString(), { signal: AbortSignal.timeout(5000) });
+        const baseResp = await scopedFetch(baselineUrl.toString(), context.scope, { signal: AbortSignal.timeout(5000) });
         const baseBody = await baseResp.text();
         baselineLength = baseBody.length;
       } catch {
@@ -2625,7 +2728,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
           const testUrl = new URL(baseUrl);
           testUrl.searchParams.set(param, payload);
 
-          const response = await fetch(testUrl.toString(), {
+          const response = await scopedFetch(testUrl.toString(), context.scope, {
             signal: AbortSignal.timeout(5000),
           });
           const body = await response.text();
@@ -2727,7 +2830,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
           const testUrl = new URL(baseUrl);
           testUrl.searchParams.set(param, payload);
 
-          const response = await fetch(testUrl.toString(), {
+          const response = await scopedFetch(testUrl.toString(), context.scope, {
             signal: AbortSignal.timeout(5000),
           });
           const body = await response.text();
@@ -2803,7 +2906,7 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
       const url = context.parameters.url as string;
 
       try {
-        const response = await fetch(url, {
+        const response = await scopedFetch(url, context.scope, {
           method: 'GET',
           signal: AbortSignal.timeout(10000),
         });
@@ -2908,14 +3011,13 @@ ${issues.length ? `Issues:\n${issues.join('\n')}` : '✓ No obvious issues'}`,
         `  ${cve.id} (CVSS: ${cve.cvss})\n    ${cve.description}`
       ).join('\n\n');
 
+      // Reference lookup, not a target probe — return the CVE list as output only and emit NO
+      // finding. A finding here would carry tool-output evidence and be stamped a "verified" critical
+      // attributed to the mission target, despite reflecting nothing about that target. The output
+      // already lists each CVE with its CVSS, so the model can still reason over the criticals.
       return {
         success: true,
         output: `CVE Lookup for "${query}":\nFound ${matches.length} matching CVE(s):\n\n${output}`,
-        findings: matches.filter(m => m.cvss >= 9.0).length > 0 ? [{
-          title: 'Critical CVEs Found',
-          severity: 'critical' as const,
-          details: `Found ${matches.filter(m => m.cvss >= 9.0).length} critical CVEs (CVSS >= 9.0): ${matches.filter(m => m.cvss >= 9.0).map(m => m.id).join(', ')}`,
-        }] : undefined,
       };
     },
   },
@@ -3204,6 +3306,12 @@ export const EXTERNAL_TOOLS: CustomTool[] = [
       const url = context.parameters.url as string;
       const wordlist = context.parameters.wordlist as string || '/usr/share/wordlists/dirb/common.txt';
       const mc = context.parameters.mc as string || '200,301,302,403';
+
+      // A wordlist path is LLM-controlled and its lines are sent to the target — refuse one that points
+      // at local keys/credentials so the tool can't be turned into a file-exfiltration primitive.
+      if (isSensitiveFilePath(wordlist)) {
+        return { success: false, error: `Refused: wordlist path '${wordlist}' resolves to sensitive local material (keys/credentials) — its contents would be sent to the target.` };
+      }
 
       const args = ['-u', url, '-w', wordlist, '-mc', mc, '-o', '/dev/stdout', '-of', 'json', '-s'];
       const result = await runSubprocess('ffuf', args, { timeout: 120000 });

--- a/src/arsenal/path-guard.ts
+++ b/src/arsenal/path-guard.ts
@@ -1,0 +1,31 @@
+/**
+ * File-path guard shared by the fuzz / credential tools (built-in ffuf, adapter ffuf/gobuster, hydra).
+ *
+ * These tools take a wordlist / userlist / passlist path from LLM-controlled parameters and send each
+ * line to the (in-scope, possibly attacker-controlled) target, so pointing one at a key/credential file
+ * would exfiltrate it line-by-line. This denies the high-value secrets — SSH/PGP/cloud-cred dotdirs,
+ * the shadow file, and private-key files — with near-zero collision against ordinary wordlists
+ * (SecLists, /usr/share/wordlists/…). It lives in its own module so arsenal/index.ts, adapter-tools.ts,
+ * and post-ex.ts can all import it without a circular dependency. Pure (home injectable for tests).
+ */
+import { homedir } from 'os';
+import { resolve as resolvePath, basename, sep, join as joinPath } from 'path';
+
+/** Secret directories under the operator's home whose contents must never be fed to a target. */
+const SECRET_HOME_DIRS = ['.ssh', '.aws', '.gnupg', '.config'];
+
+export function isSensitiveFilePath(p: string | undefined, home: string = homedir()): boolean {
+  if (!p || typeof p !== 'string') return false;
+  const expanded = p.startsWith('~') ? home + p.slice(1) : p;
+  const lower = resolvePath(expanded).toLowerCase();
+  const homeLower = home.toLowerCase();
+  const base = basename(lower);
+
+  for (const d of SECRET_HOME_DIRS) {
+    const dir = joinPath(homeLower, d);
+    if (lower === dir || lower.startsWith(dir + sep)) return true;
+  }
+  if (lower === '/etc/shadow' || lower === '/etc/gshadow') return true;
+  if (/^id_(rsa|dsa|ecdsa|ed25519)$/.test(base) || base.endsWith('.pem')) return true;
+  return false;
+}

--- a/src/arsenal/post-ex.ts
+++ b/src/arsenal/post-ex.ts
@@ -20,6 +20,7 @@
 
 import type { AdapterToolDeps } from './adapter-tools.js';
 import type { CustomTool, ToolContext, ToolResult } from '../types/index.js';
+import { isSensitiveFilePath } from './path-guard.js';
 
 const str = (v: unknown): string | undefined =>
   typeof v === 'string' && v.trim() ? v.trim() : undefined;
@@ -175,6 +176,11 @@ export function createHydraTool(deps: AdapterToolDeps): CustomTool {
     // Refuse option-looking credential values that hydra would reparse as its own flags.
     for (const [label, val] of [['user', user], ['password', password], ['userlist', userlist], ['passlist', passlist]] as const) {
       if (val && optionLooking(val)) return { success: false, error: `hydra: refusing option-looking ${label} '${val}'.` };
+    }
+    // A user/pass LIST path is LLM-controlled and hydra reads it and sends each line to the target —
+    // refuse one that points at local keys/credentials so it can't become a file-exfiltration primitive.
+    for (const [label, val] of [['userlist', userlist], ['passlist', passlist]] as const) {
+      if (val && isSensitiveFilePath(val)) return { success: false, error: `hydra: refusing ${label} '${val}' — resolves to sensitive local material (keys/credentials).` };
     }
     if (deps.scopeOk && !deps.scopeOk(target)) {
       return { success: false, error: `SCOPE DENIED: target '${target}' is not in the authorized scope — hydra refused before execution.` };

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,8 @@ import {
   scopeViolation,
   runSubprocess,
   isToolAvailable,
+  isLoopbackTargetHost,
+  isPrivateTargetHost,
 } from './arsenal/index.js';
 import { buildAdapterTools } from './arsenal/adapter-tools.js';
 import { buildPostExTools } from './arsenal/post-ex.js';
@@ -527,7 +529,13 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     const allowedHosts = this.targetEnv.getAllTargets()
       .map((t) => hostFromTargetValue(t.address))
       .filter((h): h is string => !!h);
-    this.arsenal.setScope({ allowedHosts, allowLoopback: true, allowPrivate: true });
+    // Admit loopback / RFC1918 ranges IMPLICITLY only when the mission itself explicitly targets one.
+    // A public-only engagement must not leave the entire private internet + loopback (incl. the local
+    // War Room control plane and cloud IMDS) in scope for an LLM-supplied target. An explicitly-added
+    // private/loopback target is still reachable via the exact-host allowlist regardless of these flags.
+    const allowLoopback = allowedHosts.some(isLoopbackTargetHost);
+    const allowPrivate = allowedHosts.some(isPrivateTargetHost);
+    this.arsenal.setScope({ allowedHosts, allowLoopback, allowPrivate });
   }
 
   /**
@@ -591,6 +599,7 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
             status: 'pending',
             priority: 20,
             dependencies: [],
+            targetAddress: this.targetEnv.getTarget(finding.targetId)?.address,
             createdAt: Date.now(),
           });
           this.followupsSpawned++;
@@ -950,7 +959,11 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
       // must leave the task pending (not permanently assigned + stuck in
       // activeDispatches with no completion path to clear it).
       const allTargets = this.targetEnv.getAllTargets();
-      const target = allTargets.find(t => task.description.includes(t.address)) || allTargets[0];
+      // Resolve by the task's EXACT target address first (set at creation); fall back to the legacy
+      // substring scan only for tasks predating the field, so a prefix-collision (10.0.0.1 vs
+      // 10.0.0.10) can't misroute a dispatch to the wrong target.
+      const target = (task.targetAddress ? allTargets.find(t => t.address === task.targetAddress) : undefined)
+        || allTargets.find(t => task.description.includes(t.address)) || allTargets[0];
       if (!target) continue; // No targets available — leave task pending, skip dispatch
 
       // Dispatch task (fire and forget — don't block the tick loop)
@@ -1077,14 +1090,26 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     };
 
     const needed = phaseOperators[phase] || [];
+    const mission = this.mission.getActiveMission();
+    const queue = this.mission.getTaskQueue();
     for (const archetype of needed) {
+      // Only spawn when this phase ACTUALLY has pending/assigned work for the archetype. Eagerly
+      // spawning on every phase transition (even for task-less phases like INSTALL/C2) fills the pool
+      // with idle operators and can throw at the final phase — leaving the analyst unspawnable and the
+      // mission wedged. The dispatch loop already spawns on demand (capped per archetype) for real work.
+      const hasWork = !!mission && !!queue && queue.getForMission(mission.id).some(
+        t => t.operatorType === archetype && (t.status === 'pending' || t.status === 'assigned')
+      );
+      if (!hasWork) continue;
       const existing = this.cell.getAvailableOperator(archetype);
       if (!existing) {
         const allOps = this.cell.getAllOperators();
         const hasArchetype = allOps.some(op => op.archetype === archetype);
         if (!hasArchetype) {
           const callsign = `${archetype.charAt(0).toUpperCase() + archetype.slice(1)}-Auto`;
-          this.spawnOperator(callsign, archetype);
+          // A full pool / dup callsign throws — treat as "spawn deferred to the dispatch loop", never
+          // abort the tick (which would strand the mission short of completion).
+          try { this.spawnOperator(callsign, archetype); } catch { /* pool full — dispatch loop retries */ }
         }
       }
     }

--- a/src/mcp-guards.ts
+++ b/src/mcp-guards.ts
@@ -1,0 +1,57 @@
+/**
+ * Authorization guards for the MCP recon plane.
+ *
+ * The MCP server is a standalone stdio process with no access to a running mission's egress scope, so
+ * it enforces parity with the HTTP recon endpoint's posture through these pure, dependency-free
+ * helpers: local/lab targets are free, public targets require an operator-supplied allowlist, and an
+ * option-looking ("-…") target is rejected before it can be reparsed as an nmap flag. Pure so they
+ * unit-test in isolation (the server module runs its transport on import and can't be imported directly).
+ */
+
+/**
+ * A valid recon target: a hostname / IPv4 / IPv6 literal with no shell metacharacters, AND not an
+ * option-looking leading dash (which nmap would reparse as a flag — parity with the adapter/post-ex
+ * argv guards that already reject a leading "-").
+ */
+export function validMcpTarget(target: unknown): target is string {
+  return typeof target === 'string' && /^[A-Za-z0-9._:-]+$/.test(target) && !target.startsWith('-');
+}
+
+/** Loopback / RFC1918 / link-local "lab" target — reachable without an allowlist entry, mirroring the
+ *  War Room recon endpoint's "local/lab free" posture. */
+export function isLocalLabTarget(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, '');
+  return h === 'localhost' || h === '::1' || h.endsWith('.local')
+    || /^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)
+    || /^172\.(1[6-9]|2\d|3[01])\./.test(h)
+    || /^169\.254\./.test(h);
+}
+
+/**
+ * Decide whether MCP recon may scan a target. Local/lab targets are always allowed; a public target
+ * must appear in `allowlist` exactly or as a subdomain; an invalid/option-looking target is refused.
+ */
+export function mcpTargetDecision(
+  target: unknown,
+  allowlist: string[],
+): { allowed: true; host: string } | { allowed: false; reason: string } {
+  if (!validMcpTarget(target)) {
+    return {
+      allowed: false,
+      reason: 'Invalid target: only hostnames / IPv4 / IPv6 literals are allowed ([A-Za-z0-9._:-]), and a target may not begin with "-".',
+    };
+  }
+  const host = target.toLowerCase();
+  if (isLocalLabTarget(host)) return { allowed: true, host };
+  const allow = allowlist.map((a) => a.trim().toLowerCase()).filter(Boolean);
+  if (allow.some((a) => a === host || host.endsWith('.' + a))) return { allowed: true, host };
+  return {
+    allowed: false,
+    reason: 'Target not authorized: a public target must be listed in T3MP3ST_MCP_ALLOWED_TARGETS (host or a parent domain). Local/lab targets are allowed by default.',
+  };
+}
+
+/** Read the operator's public-target allowlist from the environment (comma-separated). */
+export function mcpAllowlistFromEnv(env: NodeJS.ProcessEnv = process.env): string[] {
+  return (env.T3MP3ST_MCP_ALLOWED_TARGETS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -16,12 +16,10 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { mcpTargetDecision, mcpAllowlistFromEnv } from './mcp-guards.js';
+import { redactString } from './redact.js';
 
 const execFileAsync = promisify(execFile);
-
-// Strict target allowlist: hostnames, IPv4/IPv6, no shell metacharacters.
-// Anything outside this set is rejected before it can reach a subprocess.
-const TARGET_RE = /^[A-Za-z0-9._:-]+$/;
 
 // =============================================================================
 // COMPREHENSIVE PAYLOAD DATABASES
@@ -114,15 +112,16 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
     case 'security_recon': {
       const { target, scan_type = 'quick' } = args as any;
 
-      // Validate the target BEFORE it reaches any subprocess. Only hostnames /
-      // IPv4 / IPv6 literals are permitted; shell metacharacters (';', '|',
-      // '&', '$', spaces, backticks, ...) are rejected here. Combined with the
-      // no-shell execFile call below, "evil.com; id" is refused and, even if it
-      // slipped through, would be passed as a single inert argv entry.
-      if (typeof target !== 'string' || !TARGET_RE.test(target)) {
+      // Authorize the target BEFORE it reaches any subprocess. Only hostnames / IPv4 / IPv6 literals
+      // are permitted (shell metacharacters and option-looking "-…" targets are rejected), AND a
+      // public target must be listed in T3MP3ST_MCP_ALLOWED_TARGETS — parity with the HTTP recon
+      // endpoint's approval gate — while local/lab targets stay frictionless. Combined with the
+      // no-shell execFile call below, a metacharacter target is refused and would be inert anyway.
+      const decision = mcpTargetDecision(target, mcpAllowlistFromEnv());
+      if (!decision.allowed) {
         return JSON.stringify({
-          error: 'Invalid target: only hostnames, IPv4/IPv6 addresses are allowed ([A-Za-z0-9._:-]).',
-          target: typeof target === 'string' ? target : String(target)
+          error: decision.reason,
+          target: typeof target === 'string' ? target : String(target),
         }, null, 2);
       }
 
@@ -157,12 +156,12 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         results: {
           dns: {
             success: dns.success,
-            records: dns.output.trim().split('\n').filter(Boolean)
+            records: redactString(dns.output).trim().split('\n').filter(Boolean)
           },
           ports: {
             success: ports.success,
-            output: ports.output,
-            error: ports.error
+            output: redactString(ports.output),
+            error: ports.error ? redactString(ports.error) : ports.error
           }
         },
         commands_executed: [

--- a/src/mission/index.ts
+++ b/src/mission/index.ts
@@ -293,15 +293,17 @@ export class MissionControl extends EventEmitter<MissionEvents> {
     const mission = this.getActiveMission();
     if (!mission) return;
 
-    // Check if we already have tasks for this target (avoid duplicates)
+    // Dedup on the EXACT target address (routing key), not a substring of the free-text description —
+    // otherwise a target whose address is a prefix of another (e.g. 10.0.0.1 vs 10.0.0.10) is wrongly
+    // treated as already-seeded and never assessed. Tasks predating the field fall back to the old test.
     const existingTasks = this.taskQueue.getForMission(mission.id);
     const alreadyHasTasksForTarget = existingTasks.some(t =>
-      t.description.includes(targetAddress)
+      t.targetAddress != null ? t.targetAddress === targetAddress : t.description.includes(targetAddress)
     );
     if (alreadyHasTasksForTarget) return;
 
-    // Always start with recon tasks
-    const reconTasks = createReconTasks(mission.id, targetAddress);
+    // Always start with recon tasks, tagged with the exact target address for routing.
+    const reconTasks = createReconTasks(mission.id, targetAddress).map(t => ({ ...t, targetAddress }));
     this.taskQueue.addMany(reconTasks);
   }
 
@@ -329,7 +331,7 @@ export class MissionControl extends EventEmitter<MissionEvents> {
     }
 
     if (tasks.length > 0) {
-      this.taskQueue.addMany(tasks);
+      this.taskQueue.addMany(tasks.map(t => ({ ...t, targetAddress })));
     }
   }
 

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -274,6 +274,14 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
   /** Shared pack board (Phase-2). Attached only when swarm coordination is on; absent = solo baseline. */
   private board?: PackBoard;
   private cooldownTimer: NodeJS.Timeout | null = null;
+  /** Resolver for the in-flight cooldown Promise (see applyCooldown). Hoisted so an interruption
+   *  (abort/burn/exfiltrate) that clears the timer can also settle the awaiting promise, instead of
+   *  leaking a permanently-pending assignTask. */
+  private cooldownResolve: (() => void) | null = null;
+  /** Monotonic dispatch generation, bumped when a dispatch is reaped (abortActiveTask). A late-settling
+   *  assignTask compares the epoch it started with and skips shared-state mutations if it no longer
+   *  matches — the operator has since been re-dispatched a new task. */
+  private dispatchEpoch = 0;
   private findings: Finding[] = [];
   private credentials: Credential[] = [];
   /** White-box source excerpt (security-prioritized), set by TempestCommand.setWhiteboxSource */
@@ -336,10 +344,16 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
   /**
    * Assign a task to the operator
    */
-  async assignTask(task: Task, target?: Target): Promise<TaskResult> {
+  async assignTask(task: Task, target?: Target, inheritedEpoch?: number): Promise<TaskResult> {
     if (!this.isAvailable()) {
       throw new Error(`Operator ${this.callsign} is not available (status: ${this._state.status})`);
     }
+
+    // Capture the dispatch generation at the OUTERMOST call; decompose subtasks inherit it, so the whole
+    // chain is tied to one dispatch. If this settle finds the epoch no longer matches, the dispatch was
+    // reaped (abortActiveTask) and the operator may already own a newer task — we must not touch shared
+    // state. (T-10 late-settle race.)
+    const myEpoch = inheritedEpoch ?? this.dispatchEpoch;
 
     this.setStatus('tasked');
     this._state.currentTask = task.id;
@@ -351,6 +365,12 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
       this.setStatus('executing');
       const result = await this.executeTask(task, target);
 
+      if (this.dispatchEpoch !== myEpoch) {
+        // Orphaned settle — return our result without touching shared operator state (no double count,
+        // no wiping the new task's currentTask, no forcing an unexpected cooldown).
+        return result;
+      }
+
       this._state.completedTasks++;
       this._state.currentTask = null;
 
@@ -361,10 +381,15 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
 
       return result;
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      if (this.dispatchEpoch !== myEpoch) {
+        // Orphaned settle — surface the error to our caller but do not mutate shared operator state.
+        return { success: false, error: errorMessage };
+      }
+
       this._state.failedTasks++;
       this._state.currentTask = null;
-
-      const errorMessage = error instanceof Error ? error.message : String(error);
 
       // Decompose fallback: if we have an LLM and retries left, break the
       // failed task into smaller subtasks instead of giving up.
@@ -378,7 +403,7 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
           const subResults: TaskResult[] = [];
           for (const sub of subtasks) {
             (sub as any)._decomposeAttempt = attempt + 1;
-            const r = await this.assignTask(sub, target);
+            const r = await this.assignTask(sub, target, myEpoch);
             subResults.push(r);
           }
 
@@ -639,12 +664,22 @@ Respond in a structured format.`;
     this.emit('cooldown:started', { durationMs: this.config.cooldownMs });
 
     await new Promise<void>(resolve => {
+      this.cooldownResolve = resolve;
       this.cooldownTimer = setTimeout(() => {
+        this.cooldownTimer = null;
+        this.cooldownResolve = null;
         this.setStatus('idle');
         this.emit('cooldown:ended');
         resolve();
       }, this.config.cooldownMs);
     });
+  }
+
+  /** Clear a pending cooldown timer AND settle its awaiting promise, so an interruption never leaks a
+   *  permanently-pending assignTask. Safe to call with no cooldown active (both guards no-op). */
+  private clearCooldown(): void {
+    if (this.cooldownTimer) { clearTimeout(this.cooldownTimer); this.cooldownTimer = null; }
+    if (this.cooldownResolve) { const resolve = this.cooldownResolve; this.cooldownResolve = null; resolve(); }
   }
 
   /**
@@ -665,10 +700,7 @@ Respond in a structured format.`;
    * Burn the operator (mark as compromised)
    */
   burn(): void {
-    if (this.cooldownTimer) {
-      clearTimeout(this.cooldownTimer);
-      this.cooldownTimer = null;
-    }
+    this.clearCooldown();
     this.setStatus('burned');
   }
 
@@ -676,10 +708,7 @@ Respond in a structured format.`;
    * Exfiltrate the operator (successful extraction)
    */
   exfiltrate(): void {
-    if (this.cooldownTimer) {
-      clearTimeout(this.cooldownTimer);
-      this.cooldownTimer = null;
-    }
+    this.clearCooldown();
     this.setStatus('exfiltrated');
   }
 
@@ -706,10 +735,10 @@ Respond in a structured format.`;
     if (this._state.status === 'idle' || this._state.status === 'burned' || this._state.status === 'exfiltrated') {
       return;
     }
-    if (this.cooldownTimer) {
-      clearTimeout(this.cooldownTimer);
-      this.cooldownTimer = null;
-    }
+    this.clearCooldown();
+    // Bump the dispatch generation so the reaped dispatch's late settle (if the hung promise ever
+    // resolves) skips its shared-state mutations instead of stomping the operator's next task.
+    this.dispatchEpoch++;
     this._state.failedTasks++;
     this._state.currentTask = null;
     this._state.lastActivityTime = Date.now();

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -28,9 +28,16 @@ export const SECRET_PATTERNS: Record<string, { pattern: RegExp; severity: string
 
 export function redactString(value: string): string {
   let redacted = value;
-  for (const { pattern } of Object.values(SECRET_PATTERNS)) {
+  for (const [name, { pattern }] of Object.entries(SECRET_PATTERNS)) {
     pattern.lastIndex = 0;
-    redacted = redacted.replace(pattern, '[redacted]');
+    if (name === 'aws_secret_key') {
+      // Skip a pure-hex 40/64-char run (SHA-1 / git commit SHA / TLS fingerprint / hex blob): a real
+      // AWS secret is mixed-case base64 with /,+,= and is never all-hex, so this never misses one but
+      // stops the pattern from corrupting legitimate hashes in served evidence.
+      redacted = redacted.replace(pattern, (m) => (/^[0-9a-fA-F]+$/.test(m) ? m : '[redacted]'));
+    } else {
+      redacted = redacted.replace(pattern, '[redacted]');
+    }
   }
   return redacted
     .replace(/Bearer\s+[A-Za-z0-9._~+/=-]{16,}/gi, 'Bearer [redacted]')

--- a/src/server.ts
+++ b/src/server.ts
@@ -5809,10 +5809,12 @@ app.get('/api/selfimprove/ledger', async (_req: Request, res: Response): Promise
   const tactics = await readText('current.md');
   const generations = ledger && Array.isArray(ledger.generations) ? ledger.generations : [];
   res.json({
+    // Evolution artifacts are LLM-authored and can incorporate tool/target output, so scrub them at
+    // the serve boundary like every other findings-bearing response.
     available: generations.length > 0,
-    generations,
-    proposalsLedger: proposalsLedger || null,
-    tactics,
+    generations: redactSecrets(generations),
+    proposalsLedger: proposalsLedger ? redactSecrets(proposalsLedger) : null,
+    tactics: redactLedgerText(tactics),
   });
 });
 
@@ -6164,7 +6166,7 @@ app.get('/api/mission/status', (_req: Request, res: Response) => {
   const findings = cmd.vault.getAllFindings();
   const allOperators = cmd.cell.getAllOperators().map(op => op.getSummary());
 
-  res.json({
+  res.json(redactSecrets({
     active: status.running,
     paused: status.paused,
     name: status.name,
@@ -6192,7 +6194,7 @@ app.get('/api/mission/status', (_req: Request, res: Response) => {
       operatorId: f.operatorId,
       discoveredAt: f.discoveredAt,
     })),
-  });
+  }));
 });
 
 /**
@@ -6401,7 +6403,9 @@ app.get('/api/mission/findings', (_req: Request, res: Response) => {
   }
 
   res.json({
-    findings: cmd.vault.getAllFindings(),
+    // Scrub findings before serving: a title/description/evidence field can echo a target-supplied
+    // secret, so pass the whole set through the same redactor used by /api/findings and the SSE feed.
+    findings: redactSecrets(cmd.vault.getAllFindings()),
     // Redact: never return raw harvested secrets over the API (only metadata + a
     // secretCaptured flag). Loopback-only mitigates, but a security tool must not dump
     // secrets in its own responses (external-audit P0).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -321,6 +321,9 @@ export interface Task {
   status: 'pending' | 'assigned' | 'in_progress' | 'completed' | 'failed' | 'skipped';
   priority: number;
   dependencies: string[];
+  /** Exact target address this task is scoped to (routing key). Optional for backward-compat; when
+   *  absent, callers fall back to matching an address inside the free-text `description`. */
+  targetAddress?: string;
   assignedTo?: string;
   result?: TaskResult;
   createdAt: number;
@@ -415,6 +418,9 @@ export interface ToolContext {
   operator?: string;
   mission?: string;
   parameters: Record<string, unknown>;
+  /** Active egress scope, injected by Arsenal.execute() so scope-aware handlers (scopedFetch) can
+   *  re-validate redirect hops against the same allowlist the initial request passed. */
+  scope?: import('../arsenal/index.js').ArsenalScope | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

A focused hardening pass across the tool arsenal, the MCP recon plane, output
redaction, and the mission/operator runtime. Each change tightens a boundary
or removes a sharp edge that a real engagement can hit, and every change is
covered by a test. The set is deliberately orthogonal to the other open
`fix:` PRs (see *Relationship to open PRs* below) so it can land independently.

## What's in here

**Tool arsenal — egress & local-file safety** (`src/arsenal/*`)
- The egress scope gate now refuses cloud link-local / instance-metadata
  addresses (`169.254.0.0/16`, IPv6 IMDS) on the implicit-private path even
  when private ranges are allowed, and checks the explicit allowlist first so
  an authorized host still passes.
- The built-in web tools re-validate every HTTP redirect hop against the active
  scope before following (a same-host `http→https` still follows; a cross-host
  redirect to an unintended host is refused via a shared `scopedFetch`).
- `whois_lookup` resolves the registry server through a validated helper and
  returns a clean error for an unknown/malformed TLD instead of connecting to
  an arbitrary derived host.
- `cve_lookup` returns its reference list as informational output only, no
  longer emitting a target-attributed severity finding for a static match.
- The fuzzing/credential tools reject a wordlist/list path that resolves to
  sensitive local material (SSH/PGP/cloud-cred dotdirs, the shadow file,
  private-key files); ordinary wordlists are unaffected.
- A credential or intrusive probe now always surfaces a warning and an audit
  entry when it runs, even in the ungated default posture.

**MCP recon parity** (`src/mcp-server.ts`, `src/mcp-guards.ts`)
- Brings the MCP `security_recon` tool to parity with the HTTP recon endpoint:
  local/lab targets stay frictionless, public targets require an operator
  allowlist (`T3MP3ST_MCP_ALLOWED_TARGETS`), option-looking `-…` targets are
  rejected before reaching `nmap`'s argv, and output is redacted.

**Output redaction** (`src/redact.ts`, `src/server.ts`)
- Stops the `aws_secret_key` pattern from corrupting legitimate 40/64-char
  hashes (SHA-1, commit SHAs, base64) in served evidence by skipping pure-hex
  runs.
- Applies the shared output scrubber to the mission-status, mission-findings,
  and self-improvement responses so all serialization paths are consistent.

**Mission orchestration & operator lifecycle** (`src/index.ts`,
`src/mission/index.ts`, `src/operators/index.ts`)
- Derives the egress allowlist from the mission's own targets, so private and
  loopback ranges are only in scope when a run explicitly targets one.
- Routes tasks to targets by an explicit target address instead of substring-
  matching free text (fixes dropped/misrouted work when one target address is a
  prefix of another — common in subnet sweeps).
- Spawns phase operators lazily per pending work and guards the spawn against a
  full pool, so a multi-target run always reaches the reporting phase.
- Tags each dispatch with a generation id so a slow task settling after its
  timeout can't corrupt a re-dispatched operator, and settles a cleared
  cooldown so an interrupted operator can't leak a pending task.

**Reproducibility check** (`scripts/verify-claims.mjs`)
- Credits an XBEN solve only when the reported flag matches the committed
  in-artifact oracle, and recomputes the Cybench solved count from the per-task
  results rather than the aggregate scalar.

## Relationship to open PRs

This branch is intentionally kept clear of the areas other open PRs already
cover, so there are no line conflicts:
- It does **not** touch the SSE endpoint or the `/api/tools/execute` target
  handling (#11's area).
- It does **not** add a PEM-block redaction pattern (#12's area) — only the
  complementary hash-over-redaction fix in `redactString`.
- The redaction-endpoint wraps here are on different routes than #11 touches.

## Testing

- `npm test` → 326 passing (adds targeted tests for each change).
- `npm run typecheck` → clean.
- `npm run build` → clean.
- `npm run verify-claims` → 24/24.
- Exercised the changed flows against the running app: booted the War Room
  server and confirmed the redaction-wrapped endpoints serve correctly; drove
  the MCP server over stdio (public target denied, lab target allowed, recon
  ran); and drove the egress scope + redirect handling through the public API
  (off-scope/metadata/redirect targets refused, in-scope and same-host
  redirects allowed).
