### PR TITLE
fix: stop dropping source files whose name contains an exclude fragment

### DIFF
--- a/src/recon/code-ingest.ts
+++ b/src/recon/code-ingest.ts
@@ -212,14 +212,13 @@ const EXPOSURE_BASE: Record<Exposure, number> = {
 // =============================================================================
 
 function isExcluded(path: string, excludeGlobs: string[]): boolean {
-  // Loose match: any exclude fragment appearing as a path segment (or substring)
-  // rejects the path. Prototype-grade — not a real glob engine.
+  // Bare fragments match a path SEGMENT only; glob (`*`) entries match as a
+  // substring.
   const segments = path.split(sep);
   for (const ex of excludeGlobs) {
     if (!ex) continue;
-    // Treat a bare fragment as "matches any segment equal to it OR any substring".
     if (segments.includes(ex)) return true;
-    if (path.includes(ex)) return true;
+    if (ex.includes('*') && path.includes(ex.replace(/\*/g, ''))) return true;
   }
   return false;
 }


### PR DESCRIPTION
before this, a source file was skipped whenever its name merely contained "test", "build", "dist" or "venv".so real code like attestation.py (auth), build_query.py (a sql builder) and distributor.py was silently dropped and the hunt never looked at it. now those files are ingested.
the crawl exclusion did an unanchored substring match against the whole path. bare fragments now only match path segments (so tests/ and build/ directories still drop), and glob-style excludes keep substring behaviour