### PR TITLE
fix: avoid loading caller cwd dotenv in server

### DIFF
--- a/src/__tests__/api-key-env-static.test.ts
+++ b/src/__tests__/api-key-env-static.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const configSource = readFileSync(join(process.cwd(), 'src/config/index.ts'), 'utf8');
+const serverSource = readFileSync(join(process.cwd(), 'src/server.ts'), 'utf8');
 const setupScript = readFileSync(join(process.cwd(), 'scripts/setup-api.sh'), 'utf8');
 
 function configLoadEnvBlock(): string {
@@ -19,6 +20,11 @@ describe('API key environment handling hardening', () => {
 
     expect(block).not.toContain("join(process.cwd(), '.env')");
     expect(block).toContain("join(homedir(), '.t3mp3st', '.env')");
+  });
+
+  it('the API server does not re-enable caller-cwd dotenv loading before ConfigManager runs', () => {
+    expect(serverSource).not.toMatch(/from ['"]dotenv['"]/);
+    expect(serverSource).not.toMatch(/\bdotenv\.config\s*\(/);
   });
 
   it('ConfigManager uses env keys in-memory and does not persist imported env keys', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,9 +32,6 @@ import type { OperatorArchetype } from './types/index.js';
 import { listOperatorPrompts, setOperatorOverride, resetOperatorOverride, type OperatorOverride } from './operators/index.js';
 import { ingestRepoToSourceContext, runWhiteboxAnalysis, resolveContainedRepoPath, RepoPathError } from './recon/whitebox.js';
 import { redactCredential } from './evidence/index.js';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 const execFileAsync = promisify(execFile);
 


### PR DESCRIPTION
## Summary
- Remove the API server's top-level `dotenv.config()` call so it does not implicitly import `.env` from the caller's working directory.
- Add a static regression check alongside the existing API-key env hardening tests.

## Bug verified
`ConfigManager` already avoids `process.cwd()/.env`, but `src/server.ts` imported `dotenv` and called `dotenv.config()` before the server initialized. When T3MP3ST is run from or inside an audited target repo, that re-enables cwd `.env` loading and can contaminate the server process with unrelated target secrets.

RED before fix:
- `npx vitest run src/__tests__/api-key-env-static.test.ts` failed on the new invariant because `src/server.ts` still contained `import dotenv from 'dotenv'` / `dotenv.config()`.

## Test plan
- `npx vitest run src/__tests__/api-key-env-static.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint` (existing warnings only, 0 errors)
- `npm run verify-claims`
