### PR TITLE
fix: report processed files after ingest byte cap

### DIFF
--- a/src/__tests__/ingest-limits.test.ts
+++ b/src/__tests__/ingest-limits.test.ts
@@ -36,6 +36,8 @@ describe('ingest ceilings (bounded ingest, non-regressing)', () => {
     const dir = makeRepo(20); dirs.push(dir);
     const res = ingestRepository(cfg(dir, { maxTotalBytes: 50 })); // ~30 bytes/file → breaks after ~2
     expect(res.stats.truncated).toBe(true);
+    expect(res.stats.files).toBeLessThan(20);
+    expect(res.stats.files).toBe(res.stats.blocks); // fixture has one block per processed file
     expect(res.stats.blocks).toBeGreaterThan(0);
   });
 

--- a/src/recon/code-ingest.ts
+++ b/src/recon/code-ingest.ts
@@ -753,6 +753,7 @@ export function ingestRepository(config: IngestConfig): IngestResult {
   let truncated = config.maxFiles !== undefined && files.length >= config.maxFiles;
 
   const allBlocks: CodeBlock[] = [];
+  let processedFiles = 0;
   for (const path of files) {
     let content: string;
     try {
@@ -760,6 +761,7 @@ export function ingestRepository(config: IngestConfig): IngestResult {
     } catch {
       continue;
     }
+    processedFiles += 1;
     totalBytes += content.length;
     allBlocks.push(...parseFile(path, content));
     if (maxTotalBytes !== undefined && totalBytes >= maxTotalBytes) {
@@ -775,7 +777,7 @@ export function ingestRepository(config: IngestConfig): IngestResult {
   const reach = reachability(callGraph, entryPoints);
 
   const stats: IngestResult['stats'] = {
-    files: files.length,
+    files: processedFiles,
     blocks: allBlocks.length,
     exposed_externally: 0,
     exposed_internally: 0,


### PR DESCRIPTION
## Summary
- Track the number of files actually read and analyzed during ingest.
- Report `stats.files` from processed files instead of the full crawl list when `maxTotalBytes` stops ingest early.
- Add a regression assertion for byte-budget truncation telemetry.

## Bug verified
With `maxTotalBytes`, `crawl()` can discover all matching files, but `ingestRepository()` stops parsing after the byte ceiling trips. Before this patch `stats.files` still reported the full crawl count, so telemetry could claim all files were analyzed even though only the prefix was parsed.

RED before fix:
- `npx vitest run src/__tests__/ingest-limits.test.ts` failed because `stats.files` was `20` even though the byte ceiling stopped after the first ~2 fixture files.

## Test plan
- `npx vitest run src/__tests__/ingest-limits.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint` (existing warnings only, 0 errors)
- `npm run verify-claims`
