### PR TITLE
fix: keep API key setup and export in sync

### DIFF
--- a/scripts/setup-api.sh
+++ b/scripts/setup-api.sh
@@ -10,10 +10,11 @@ echo "║           T3MP3ST API KEY CONFIGURATION                   ║"
 echo "╚═══════════════════════════════════════════════════════════╝"
 echo ""
 
-ENV_FILE="$(dirname "$0")/../.env"
+ENV_FILE="$HOME/.t3mp3st/.env"
+mkdir -p "$(dirname "$ENV_FILE")"
 
 if [ -f "$ENV_FILE" ]; then
-    echo "[*] Existing .env file found; it will be replaced after you enter a new key."
+    echo "[*] Existing T3MP3ST env file found; it will be replaced after you enter a new key."
 fi
 
 echo ""
@@ -64,24 +65,12 @@ esac
 
 chmod 600 "$ENV_FILE"
 
-# Add .env to gitignore if not already there
-GITIGNORE="$(dirname "$0")/../.gitignore"
-if [ -f "$GITIGNORE" ]; then
-    if ! grep -q "^\.env$" "$GITIGNORE"; then
-        echo ".env" >> "$GITIGNORE"
-        echo "[+] Added .env to .gitignore"
-    fi
-else
-    echo ".env" > "$GITIGNORE"
-    echo "[+] Created .gitignore with .env"
-fi
-
 echo ""
 echo "╔═══════════════════════════════════════════════════════════╗"
 echo "║              CONFIGURATION COMPLETE!                       ║"
 echo "╚═══════════════════════════════════════════════════════════╝"
 echo ""
-echo "Your API key has been saved to .env (mode 600)"
+echo "Your API key has been saved to $ENV_FILE (mode 600)"
 echo ""
 echo "Start the server with:"
 echo "  npm run server"

--- a/src/__tests__/api-key-env-static.test.ts
+++ b/src/__tests__/api-key-env-static.test.ts
@@ -5,12 +5,24 @@ import { join } from 'path';
 const configSource = readFileSync(join(process.cwd(), 'src/config/index.ts'), 'utf8');
 const setupScript = readFileSync(join(process.cwd(), 'scripts/setup-api.sh'), 'utf8');
 
-function configLoadEnvBlock(): string {
-  const start = configSource.indexOf('private loadEnvVariables(): void');
-  expect(start).toBeGreaterThanOrEqual(0);
-  const end = configSource.indexOf('\n  /**\n   * Get all settings', start);
-  expect(end).toBeGreaterThan(start);
+function sourceBlock(startMarker: string, endMarker: string): string {
+  const start = configSource.indexOf(startMarker);
+  expect(start, `missing start marker ${startMarker}`).toBeGreaterThanOrEqual(0);
+  const end = configSource.indexOf(endMarker, start);
+  expect(end, `missing end marker ${endMarker}`).toBeGreaterThan(start);
   return configSource.slice(start, end);
+}
+
+function configLoadEnvBlock(): string {
+  return sourceBlock('private loadEnvVariables(): void', '\n  /**\n   * Get all settings');
+}
+
+function exportConfigBlock(): string {
+  return sourceBlock('exportConfig(filePath: string): void', '\n  /**\n   * Create a .env template file');
+}
+
+function envTemplateBlock(): string {
+  return sourceBlock('createEnvTemplate(filePath:', '\n    writeFileSync(filePath, template);');
 }
 
 describe('API key environment handling hardening', () => {
@@ -19,6 +31,30 @@ describe('API key environment handling hardening', () => {
 
     expect(block).not.toContain("join(process.cwd(), '.env')");
     expect(block).toContain("join(homedir(), '.t3mp3st', '.env')");
+  });
+
+  it('setup-api.sh writes the same T3MP3ST-owned env file that ConfigManager reads', () => {
+    const block = configLoadEnvBlock();
+
+    expect(setupScript).not.toMatch(/dirname "\$0"\).*\.\.\/\.env/);
+    expect(setupScript).toMatch(/\.t3mp3st/);
+    expect(setupScript).toMatch(/mkdir\s+-p\s+"\$\(dirname "\$ENV_FILE"\)"/);
+    expect(block).toContain("join(homedir(), '.t3mp3st', '.env')");
+  });
+
+  it('env template points users at the T3MP3ST-owned env file, not a caller-cwd .env', () => {
+    const block = envTemplateBlock();
+
+    expect(block).toContain('~/.t3mp3st/.env');
+    expect(block).not.toContain('Copy this file to .env');
+  });
+
+  it('exportConfig redacts every supported provider key slot', () => {
+    const block = exportConfigBlock();
+
+    for (const provider of ['openrouter', 'venice', 'anthropic', 'openai', 'xai']) {
+      expect(block).toContain(`${provider}: settings.apiKeys.${provider} ? '***REDACTED***' : undefined`);
+    }
   });
 
   it('ConfigManager uses env keys in-memory and does not persist imported env keys', () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -793,8 +793,10 @@ class ConfigManager {
       ...settings,
       apiKeys: {
         openrouter: settings.apiKeys.openrouter ? '***REDACTED***' : undefined,
+        venice: settings.apiKeys.venice ? '***REDACTED***' : undefined,
         anthropic: settings.apiKeys.anthropic ? '***REDACTED***' : undefined,
         openai: settings.apiKeys.openai ? '***REDACTED***' : undefined,
+        xai: settings.apiKeys.xai ? '***REDACTED***' : undefined,
       },
     };
     writeFileSync(filePath, JSON.stringify(safeSettings, null, 2));
@@ -805,11 +807,16 @@ class ConfigManager {
    */
   createEnvTemplate(filePath: string = join(process.cwd(), '.env.template')): void {
     const template = `# T3MP3ST Environment Configuration
-# Copy this file to .env and fill in your API keys
+# Save this file as ~/.t3mp3st/.env and fill in your API keys
+# The setup script writes the same T3MP3ST-owned file.
 
 # OpenRouter API Key (recommended - access to multiple models)
 # Get your key at: https://openrouter.ai/keys
 OPENROUTER_API_KEY=
+
+# Venice API Key
+# Get your key at: https://venice.ai
+VENICE_API_KEY=
 
 # Anthropic API Key (direct Claude access)
 # Get your key at: https://console.anthropic.com/
@@ -818,6 +825,10 @@ ANTHROPIC_API_KEY=
 # OpenAI API Key
 # Get your key at: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
+
+# xAI API Key
+# Get your key at: https://console.x.ai/
+XAI_API_KEY=
 `;
     writeFileSync(filePath, template);
   }


### PR DESCRIPTION
## Summary
- Make `setup:api` write API keys to the same `~/.t3mp3st/.env` file that `ConfigManager` loads.
- Update generated env-template instructions to point at the T3MP3ST-owned env path and include Venice/xAI key slots.
- Include `venice` and `xai` in redacted config exports so export coverage matches supported providers.

## Bugs verified
1. `scripts/setup-api.sh` wrote a repo-local `.env`, but `ConfigManager.loadEnvVariables()` intentionally reads only `~/.t3mp3st/.env` / `~/.env`; setup could therefore create a key file the server no longer loaded.
2. `exportConfig()` supported only `openrouter`, `anthropic`, and `openai` redaction slots even though `venice` and `xai` are supported in settings and `getApiKey()`.

RED before fix:
- `npx vitest run src/__tests__/api-key-env-static.test.ts` failed on the new setup-path, env-template, and provider-export invariants.

## Test plan
- `npx vitest run src/__tests__/api-key-env-static.test.ts`
- `bash -n scripts/setup-api.sh`
- `npm test`
- `npm run typecheck`
- `npm run lint` (existing warnings only, 0 errors)
- `npm run verify-claims`
