### PR TITLE
fix: reject curl destination override flags

### DIFF
--- a/src/__tests__/local-api-hardening-static.test.ts
+++ b/src/__tests__/local-api-hardening-static.test.ts
@@ -37,10 +37,25 @@ describe('local API authorization hardening invariants', () => {
   it('/api/tools/execute rejects curl flags that change the effective destination', () => {
     const parser = sourceBlock('const CURL_TRANSPORT_OVERRIDE_FLAGS', 'function inferCommandTarget');
 
-    for (const flag of ['--resolve', '--connect-to', '--proxy', '--preproxy', '--socks5', '--socks5-hostname', '--unix-socket', '--interface']) {
+    for (const flag of [
+      '--resolve',
+      '--connect-to',
+      '--proxy',
+      '--preproxy',
+      '--socks5',
+      '--socks5-hostname',
+      '--unix-socket',
+      '--interface',
+      '--url',
+      '--config',
+      '--next',
+      '-K',
+    ]) {
       expect(parser).toContain(`'${flag}'`);
     }
     expect(parser).toMatch(/findCurlTransportOverrideFlag\(args\)/);
+    expect(parser).toMatch(/countCurlUrlOperands\(args\)\s*>\s*1/);
+    expect(parser).toMatch(/multiple URL operands/);
     expect(parser).toMatch(/changes the effective network destination/);
   });
 

--- a/src/__tests__/local-api-hardening-static.test.ts
+++ b/src/__tests__/local-api-hardening-static.test.ts
@@ -4,12 +4,16 @@ import { join } from 'path';
 
 const serverSource = readFileSync(join(process.cwd(), 'src/server.ts'), 'utf8');
 
-function routeBlock(startMarker: string, endMarker: string): string {
+function sourceBlock(startMarker: string, endMarker: string): string {
   const start = serverSource.indexOf(startMarker);
-  expect(start, `missing route marker ${startMarker}`).toBeGreaterThanOrEqual(0);
+  expect(start, `missing source marker ${startMarker}`).toBeGreaterThanOrEqual(0);
   const end = serverSource.indexOf(endMarker, start);
   expect(end, `missing end marker ${endMarker}`).toBeGreaterThan(start);
   return serverSource.slice(start, end);
+}
+
+function routeBlock(startMarker: string, endMarker: string): string {
+  return sourceBlock(startMarker, endMarker);
 }
 
 describe('local API authorization hardening invariants', () => {
@@ -28,6 +32,16 @@ describe('local API authorization hardening invariants', () => {
     expect(route).not.toMatch(/body\.target\s*\|\|\s*inferCommandTarget\(parsed\)/);
     expect(route).toMatch(/resolveCommandExecutionTarget\(body, parsed\)/);
     expect(route).toMatch(/guardAction\(body,\s*['"]command_execution['"],\s*targetResolution\.target/);
+  });
+
+  it('/api/tools/execute rejects curl flags that change the effective destination', () => {
+    const parser = sourceBlock('const CURL_TRANSPORT_OVERRIDE_FLAGS', 'function inferCommandTarget');
+
+    for (const flag of ['--resolve', '--connect-to', '--proxy', '--preproxy', '--socks5', '--socks5-hostname', '--unix-socket', '--interface']) {
+      expect(parser).toContain(`'${flag}'`);
+    }
+    expect(parser).toMatch(/findCurlTransportOverrideFlag\(args\)/);
+    expect(parser).toMatch(/changes the effective network destination/);
   });
 
   it('Admiral live launch re-checks every General-produced execution target before mission bring-up', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -344,6 +344,30 @@ interface ParsedCommand {
 
 const SHELL_META = /[|&;$<>`\\]/;
 const COMMAND_CONTROL = /[\x00-\x1F\x7F-\x9F\u2028\u2029]/;
+const CURL_TRANSPORT_OVERRIDE_FLAGS = new Set([
+  '--resolve',
+  '--connect-to',
+  '--proxy',
+  '--preproxy',
+  '--socks4',
+  '--socks4a',
+  '--socks5',
+  '--socks5-hostname',
+  '--unix-socket',
+  '--abstract-unix-socket',
+  '--interface',
+  '-x',
+]);
+
+function findCurlTransportOverrideFlag(args: string[]): string | undefined {
+  for (const arg of args) {
+    if (!arg) continue;
+    const flag = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
+    if (CURL_TRANSPORT_OVERRIDE_FLAGS.has(flag)) return flag;
+    if (arg.startsWith('-x') && arg !== '-X' && arg.length > 2) return '-x';
+  }
+  return undefined;
+}
 
 function parseCommand(command: string): ParsedCommand | { error: string } {
   if (SHELL_META.test(command) || COMMAND_CONTROL.test(command)) return { error: 'Shell control characters are not allowed; use direct argv-style commands only.' };
@@ -354,6 +378,12 @@ function parseCommand(command: string): ParsedCommand | { error: string } {
   const adapter = adapterForBinary(bin);
   if (adapter?.execution === 'catalog_only' || adapter?.execution === 'import_only') {
     return { error: `Tool is catalog-only and cannot be executed directly: ${bin}` };
+  }
+  if (bin === 'curl') {
+    const overrideFlag = findCurlTransportOverrideFlag(args);
+    if (overrideFlag) {
+      return { error: `curl flag ${overrideFlag} changes the effective network destination and is not allowed through /api/tools/execute.` };
+    }
   }
   return { bin, args };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -356,7 +356,25 @@ const CURL_TRANSPORT_OVERRIDE_FLAGS = new Set([
   '--unix-socket',
   '--abstract-unix-socket',
   '--interface',
+  '--url',
+  '--config',
+  '--next',
   '-x',
+  '-K',
+]);
+const CURL_VALUE_FLAGS = new Set([
+  '-A', '--user-agent',
+  '-b', '--cookie',
+  '-c', '--cookie-jar',
+  '-d', '--data', '--data-ascii', '--data-binary', '--data-raw', '--data-urlencode',
+  '-F', '--form',
+  '-H', '--header',
+  '-m', '--max-time',
+  '-o', '--output',
+  '-T', '--upload-file',
+  '-u', '--user',
+  '-X', '--request',
+  '--cacert', '--cert', '--connect-timeout', '--key', '--request-target', '--retry',
 ]);
 
 function findCurlTransportOverrideFlag(args: string[]): string | undefined {
@@ -365,8 +383,39 @@ function findCurlTransportOverrideFlag(args: string[]): string | undefined {
     const flag = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
     if (CURL_TRANSPORT_OVERRIDE_FLAGS.has(flag)) return flag;
     if (arg.startsWith('-x') && arg !== '-X' && arg.length > 2) return '-x';
+    if (arg.startsWith('-K') && arg.length > 2) return '-K';
   }
   return undefined;
+}
+
+function looksLikeCurlUrlOperand(arg: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\/\S+/i.test(arg)
+    || /^(?:[a-z0-9-]+\.)+[a-z]{2,}(?::\d+)?(?:[/?#].*)?$/i.test(arg)
+    || /^(?:localhost|(?:\d{1,3}\.){3}\d{1,3})(?::\d+)?(?:[/?#].*)?$/i.test(arg)
+    || /^\[[0-9a-f:]+\](?::\d+)?(?:[/?#].*)?$/i.test(arg);
+}
+
+function countCurlUrlOperands(args: string[]): number {
+  let count = 0;
+  let skipNext = false;
+  let endOfOptions = false;
+  for (const arg of args) {
+    if (!arg) continue;
+    if (skipNext) { skipNext = false; continue; }
+    if (!endOfOptions && arg === '--') { endOfOptions = true; continue; }
+    if (!endOfOptions && arg.startsWith('--')) {
+      const hasInlineValue = arg.includes('=');
+      const flag = hasInlineValue ? arg.slice(0, arg.indexOf('=')) : arg;
+      if (!hasInlineValue && CURL_VALUE_FLAGS.has(flag)) skipNext = true;
+      continue;
+    }
+    if (!endOfOptions && arg.startsWith('-')) {
+      if (arg.length === 2 && CURL_VALUE_FLAGS.has(arg)) skipNext = true;
+      continue;
+    }
+    if (looksLikeCurlUrlOperand(arg)) count += 1;
+  }
+  return count;
 }
 
 function parseCommand(command: string): ParsedCommand | { error: string } {
@@ -383,6 +432,9 @@ function parseCommand(command: string): ParsedCommand | { error: string } {
     const overrideFlag = findCurlTransportOverrideFlag(args);
     if (overrideFlag) {
       return { error: `curl flag ${overrideFlag} changes the effective network destination and is not allowed through /api/tools/execute.` };
+    }
+    if (countCurlUrlOperands(args) > 1) {
+      return { error: 'curl commands with multiple URL operands are not allowed through /api/tools/execute; submit one transfer per approved target.' };
     }
   }
   return { bin, args };


### PR DESCRIPTION
## Summary
- Reject curl transport/DNS/proxy override flags in `/api/tools/execute` parsing.
- Add a regression invariant for flags such as `--resolve`, `--connect-to`, proxy flags, Unix socket flags, and interface binding.

## Bug verified
`/api/tools/execute` authorized network commands against the parsed URL hostname, but curl can be given flags such as `--resolve approved.test:443:127.0.0.1` that keep the visible URL host as `approved.test` while connecting to a different effective destination. That makes the approval target misleading.

RED before fix:
- `npx vitest run src/__tests__/local-api-hardening-static.test.ts` failed because no curl destination-override rejection existed.

## Test plan
- `npx vitest run src/__tests__/local-api-hardening-static.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint` (existing warnings only, 0 errors)
- `npm run verify-claims`
