### PR TITLE
fix(mission): stop command loop on terminal state

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -397,6 +397,28 @@ describe('Wedged-dispatch timeout backstop', () => {
     expect(op.getSummary().failedTasks).toBe(1);
   });
 
+  it('mission completion stops the command loop so status/timer do not stay active', async () => {
+    const mod = await import('../index.js');
+    const command = new mod.TempestCommand({
+      name: 'Lifecycle Op',
+      llm: { provider: 'mock', model: 'mock-model' },
+    });
+
+    let stopped = false;
+    command.on('command:stopped', () => { stopped = true; });
+    command.start();
+
+    const mission = command.mission.getActiveMission();
+    expect(mission).toBeDefined();
+    expect(command.getStatus().running).toBe(true);
+
+    command.mission.completeMission(mission!.id);
+
+    expect(command.getStatus().running).toBe(false);
+    expect(command.mission.getActiveMission()).toBeUndefined();
+    expect(stopped).toBe(true);
+  });
+
   it('a wedged mission reaches phase advancement once the per-dispatch backstop fires', async () => {
     // Tiny backstop so the test is fast and deterministic.
     const prev = process.env.T3MP3ST_TASK_TIMEOUT_MS;

--- a/src/index.ts
+++ b/src/index.ts
@@ -496,8 +496,12 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     });
 
     // Forward mission events
-    this.mission.on('mission:completed', (_mission) => {
-      // Could trigger reporting here
+    this.mission.on('mission:completed', () => {
+      this.stop();
+    });
+
+    this.mission.on('mission:aborted', () => {
+      this.stop();
     });
 
     this.mission.on('mission:phase_changed', ({ mission, newPhase }) => {


### PR DESCRIPTION
## Summary

- Stop the `TempestCommand` tick loop when MissionControl emits `mission:completed` or `mission:aborted`.
- Add a regression test proving command status becomes inactive after mission completion.

Fixes #32.

## Problem

MissionControl already clears the active mission when a mission completes, but the outer command loop can remain running. That makes status/timer surfaces look active even after the mission is done, so operators still need to stop manually.

## Approach

Wire `mission:completed` and `mission:aborted` to the existing `TempestCommand.stop()` path. That path already clears the interval, resets running state, and emits `command:stopped`.

The regression test starts a command, completes the active mission directly through MissionControl, and verifies:

- `getStatus().running` flips from `true` to `false`
- `getActiveMission()` is cleared
- `command:stopped` is emitted

## Safety And Authority

- Target authority: `not_applicable`
- Network use during validation: `none` for the focused lifecycle test; local API was already running during `doctor`
- Active tools used: `none`
- Approval/receipt behavior changed: `no`
- Secrets/private target data in artifacts: `no`
- Redaction reviewed: `not_applicable`

## Evidence And Provenance Impact

- Findings/provenance: no change
- Report/export content: no change
- Benchmark/headline claims: no change

## Compatibility

- Platforms considered: platform-neutral Node lifecycle/event behavior
- Local-agent impact: none
- API-key provider impact: none
- UI/browser impact: improves status/timer truthfulness indirectly by stopping the command loop at terminal mission state

## Verification

```bash
npm install
npx vitest run src/__tests__/index.test.ts
npm run typecheck
npm test
npm run doctor
npm run verify-claims
```

Results:

- `npm install` -> pass, 0 vulnerabilities
- `npx vitest run src/__tests__/index.test.ts` -> pass, 1 file / 43 tests
- `npm run typecheck` -> pass
- `npm test` -> pass, 28 files / 324 tests
- `npm run doctor` -> pass, 40/40 checks
- `npm run verify-claims` -> pass, 24/24 claims verified

## Residual Risk

This does not change how tasks complete, fail, or time out. It only makes the command loop follow the mission lifecycle once MissionControl reaches a terminal state.
