### PR TITLE
docs: explain verified provenance setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Deeper reading: [WALL_FORENSICS](docs/WALL_FORENSICS.md) (per-challenge misses),
 |---|---|
 | [FEATURES.md](FEATURES.md) | feature-by-feature status (`[x]` shipped / `[~]` partial / `[ ]` planned) |
 | [SCOPE_AND_AUTHORIZATION](docs/SCOPE_AND_AUTHORIZATION.md) | authority model, scope receipts, evidence and retest rules |
+| [VERIFIED_PROVENANCE](docs/VERIFIED_PROVENANCE.md) | how findings become tool-proven instead of model-asserted |
 | [TEAM_PREVIEW](docs/TEAM_PREVIEW.md) | first-run path and review script |
 | [INSTALL_MATRIX](docs/INSTALL_MATRIX.md) | macOS / Linux readiness table |
 | [ARSENAL_ACTIVATION_PLAN](docs/ARSENAL_ACTIVATION_PLAN.md) | optional external-tool setup |

--- a/docs/VERIFIED_PROVENANCE.md
+++ b/docs/VERIFIED_PROVENANCE.md
@@ -1,0 +1,64 @@
+# Verified Provenance
+
+T3MP3ST is evidence-first: a finding should say whether it is backed by tool
+output, context, or only model reasoning.
+
+If the evidence vault says `Provenance: none` or `model-asserted`, the finding is
+not yet verified. Treat it as a hypothesis until a tool result, retest, or
+operator-supplied artifact backs the claim.
+
+## What Counts As Tool-Proven
+
+A finding becomes tool-proven when all of these are true:
+
+- The agent requests an Arsenal tool.
+- T3MP3ST executes that tool through the harness.
+- The returned output is captured as evidence.
+- The finding records the tool name or evidence reference that supports it.
+
+Final prose from a model is useful analysis, but it is not the same thing as
+tool-backed evidence.
+
+## Keyless And Local-Agent Runs
+
+For keyless runs, connect a local agent in the War Room Settings first: Claude
+Code, Codex, Hermes, or another supported local-agent backend.
+
+The local agent must request tools through T3MP3ST. If it only writes a final
+answer in prose, the harness has no tool output to attach and findings should stay
+unverified/model-asserted.
+
+For a quick sanity check:
+
+1. Start the War Room with `npm run server`.
+2. Connect a local agent in Settings.
+3. Use a local or explicitly authorized target.
+4. Run a harmless reconnaissance path.
+5. Open the evidence/finding view and check that at least one finding cites a
+   tool name and captured output.
+
+If every finding remains `Provenance: none`, the run may still be useful as a
+planning pass, but it did not verify findings through the tool loop.
+
+## Common Reasons Provenance Is Missing
+
+- No API provider or local agent is connected.
+- The chosen agent produced prose instead of a tool request.
+- The tool request could not be parsed by the local-agent/tool-call bridge.
+- The tool was catalog-only, missing locally, or receipt-gated.
+- The target or action was out of scope, so the harness correctly refused it.
+- The final report promoted model analysis before a retest or evidence item was
+  attached.
+
+## Operator Checklist
+
+Before trusting a finding:
+
+- Is there an evidence item?
+- Does the evidence item include tool output, a command result, a screenshot, or
+  another reproducible artifact?
+- Does the finding cite the evidence or tool name?
+- Did any receipt or scope gate apply?
+- Has the claim been retested or falsified?
+
+When in doubt, keep the finding labeled as unverified and queue a retest.


### PR DESCRIPTION
## Summary

- Add `docs/VERIFIED_PROVENANCE.md` explaining when a finding is tool-proven versus model-asserted.
- Link the new doc from the README documentation table.

Relates to #31.

## Problem

It is easy for operators to confuse model analysis with verified evidence. In keyless/local-agent runs, a final prose answer can still leave evidence vault entries as `Provenance: none · model-asserted (unverified)` if the agent never requested a tool or no tool output was captured.

## Approach

Add a short operator-facing doc that explains:

- what counts as tool-proven evidence;
- how keyless/local-agent runs should produce provenance;
- why prose-only findings remain unverified;
- common reasons provenance is missing;
- a checklist before trusting a finding.

This is docs-only and does not change provenance semantics.

## Safety And Authority

- Target authority: `docs_only`
- Network use during validation: `none` for tests; local API was already running during `doctor`
- Active tools used: `none`
- Approval/receipt behavior changed: `no`
- Secrets/private target data in artifacts: `no`
- Redaction reviewed: `not_applicable`

## Evidence And Provenance Impact

- Findings/provenance behavior: no runtime change
- Report/export content: no change
- Benchmark/headline claims: no change

## Compatibility

- Platforms considered: docs-only
- Local-agent impact: docs clarify Claude Code / Codex / Hermes setup expectations
- API-key provider impact: none
- UI/browser impact: README link only

## Verification

```bash
npm install
npm run typecheck
npm test
npm run doctor
npm run verify-claims
```

Results:

- `npm install` -> pass, 0 vulnerabilities
- `npm run typecheck` -> pass
- `npm test` -> pass, 28 files / 323 tests
- `npm run doctor` -> pass, 40/40 checks
- `npm run verify-claims` -> pass, 24/24 claims verified

## Residual Risk

This documents the expected provenance model but does not add UI affordances or runtime enforcement. If maintainers want the wording somewhere else, this can move into an existing operator guide instead of a standalone doc.
