### PR TITLE
docs(readme): fix local-LLM setup command (npx tempest config → npx tempest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Or run it **fully offline** on your own model — no key, no cloud. Defaults to 
 ollama serve && ollama pull llama3                          # or an OpenAI-compatible server
 export TEMPEST_LOCAL_BASE_URL=http://localhost:11434/api    # LM Studio: http://localhost:1234/v1
 export TEMPEST_LOCAL_MODEL=llama3
-npx tempest config                                          # → "Change default provider" → local
+npx tempest                                                 # → "Change default provider" → local
 ```
 
 Tool-calling works on any local model (it's driven over text), so the Arsenal runs even on models without native function-calling.


### PR DESCRIPTION
Addresses the setup confusion in #38.

The offline / local-LLM quickstart (README) instructs:

```bash
npx tempest config   # → "Change default provider" → local
```

But there is no `config` subcommand. The CLI (`src/cli.ts`) defines only `interactive` (the default command), `setup`, `status`, `test`, and `models`. Running `npx tempest config` does nothing useful — which is exactly what a commenter on #38 reported.

The "Change default provider" menu item lives in the default `interactive` command, so the correct invocation is simply:

```bash
npx tempest          # → "Change default provider" → local
```

One-line docs fix; column alignment in the code block preserved.