### PR TITLE
fix: clarify local LLM setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Or run it **fully offline** on your own model — no key, no cloud. Defaults to 
 ollama serve && ollama pull llama3                          # or an OpenAI-compatible server
 export TEMPEST_LOCAL_BASE_URL=http://localhost:11434/api    # LM Studio: http://localhost:1234/v1
 export TEMPEST_LOCAL_MODEL=llama3
+npm run build                                               # only needed from a git clone
 npx tempest                                                 # → "Change default provider" → local
 ```
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -802,6 +802,9 @@ class ConfigManager {
       case 'codex':
         this.config.set('defaultModel', this.config.get('codex').defaultModel);
         break;
+      case 'local':
+        this.config.set('defaultModel', process.env.TEMPEST_LOCAL_MODEL?.trim() || 'llama3');
+        break;
     }
   }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -281,13 +281,14 @@ async function runSetup(): Promise<void> {
     'Welcome to T3MP3ST Setup',
     `This wizard will help you configure T3MP3ST for first use.
 
-You'll need an API key from one of these providers:
+You can use a local model with no API key, or add a key from one of these providers:
+• ${chalk.cyan('Local')} - Ollama / LM Studio / vLLM via TEMPEST_LOCAL_BASE_URL
 • ${chalk.cyan('OpenRouter')} (recommended) - Access multiple models
 • ${chalk.cyan('Anthropic')} - Direct Claude access
 • ${chalk.cyan('OpenAI')} - GPT models
 
 The setup will guide you through:
-1. Adding your API key(s)
+1. Adding API key(s), if you use a hosted provider
 2. Selecting your default provider and model
 3. Configuring basic settings`,
     'cyan'
@@ -365,12 +366,11 @@ async function setupApiKeys(): Promise<void> {
     {
       type: 'checkbox',
       name: 'providers',
-      message: 'Which API keys would you like to configure?',
+      message: 'Which hosted API keys would you like to configure? Leave empty to use a local model only.',
       choices: [
         {
           name: `OpenRouter ${hasApiKey('openrouter') ? chalk.green('(configured)') : chalk.yellow('(recommended)')}`,
           value: 'openrouter',
-          checked: !hasApiKey('openrouter'),
         },
         {
           name: `Venice ${hasApiKey('venice') ? chalk.green('(configured)') : ''}`,
@@ -409,21 +409,11 @@ async function setupApiKeys(): Promise<void> {
 async function setupProvider(): Promise<void> {
   const configuredProviders = [];
 
+  configuredProviders.push({ name: 'Local model (Ollama / LM Studio / vLLM, no API key)', value: 'local' });
   if (hasApiKey('openrouter')) configuredProviders.push({ name: 'OpenRouter', value: 'openrouter' });
   if (hasApiKey('venice')) configuredProviders.push({ name: 'Venice', value: 'venice' });
   if (hasApiKey('anthropic')) configuredProviders.push({ name: 'Anthropic', value: 'anthropic' });
   if (hasApiKey('openai')) configuredProviders.push({ name: 'OpenAI', value: 'openai' });
-
-  if (configuredProviders.length === 0) {
-    showWarning('No API keys configured. Please add at least one API key first.');
-    return;
-  }
-
-  if (configuredProviders.length === 1) {
-    config.setDefaultProvider(configuredProviders[0].value as any);
-    showSuccess(`Default provider set to: ${configuredProviders[0].name}`);
-    return;
-  }
 
   const { provider } = await inquirer.prompt([
     {


### PR DESCRIPTION
## Summary
- document that git-clone CLI usage needs `npm run build` before the local CLI bin exists
- keep the upstream `npx tempest` interactive CLI path instead of the removed `config` subcommand
- make setup explicitly support keyless local model configuration and set the local default model from `TEMPEST_LOCAL_MODEL`

## Root cause
Issue 38 shifted from Ollama endpoint selection to source-checkout setup: `package.json` points the CLI bins at `dist/cli.js`, but `dist/` is generated and absent after a plain clone until `npm run build` runs. The setup wizard also framed configuration around hosted API keys even though the local provider is keyless and always available.

## Verification
- `npm run typecheck`
- `npm run build`
- `npx --no-install tempest --help`
- `npm test` (34 files, 386 tests)

Closes: elder-plinius/T3MP3ST#38
