### PR TITLE
fix(ui): War Room backbone gate stops clobbering the live-agent count

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24805,7 +24805,14 @@ Be specific and actionable. Format as structured JSON.`;
     list.innerHTML = agents.map(function(a){ return rowHtml(a); }).join('');
     const ready = agents.filter(function(a){return a.ready;}).length;
     const installed = agents.filter(function(a){return a.installed;}).length;
-    const live = Object.keys(pingStatus).filter(function(k){return pingStatus[k].ok;}).length;
+    // Live = client-side successful pings OR agents the SERVER already reports live. Agents connected
+    // server-side (autoReconnect, or a status?check=1 re-ping) are live even though THIS client never
+    // pinged them; counting only client pings here clobbered window.__t3mpLiveAgents back to 0 on every
+    // re-render, which broke the War Room backbone gate (t3mpHasBackend) for a genuinely-usable agent.
+    const clientLive = Object.keys(pingStatus).filter(function(k){return pingStatus[k].ok;}).length;
+    const serverLive = Array.isArray(window.__t3mpServerAgents)
+      ? window.__t3mpServerAgents.filter(function(a){ return a.lastPing && a.lastPing.ok; }).length : 0;
+    const live = Math.max(clientLive, serverLive);
     const sum = document.getElementById('localAgentsSummary');
     if (sum) sum.innerHTML = connectedIds.length+' active'+(live?' · '+live+' live':'')+' · '+ready+' ready · '+installed+'/'+agents.length+' installed';
     // expose live/connected counts separately. A plain connect is just a registration; only a


### PR DESCRIPTION
## Problem
On localhost with a genuinely-live local agent, the War Room shows **"No LLM backbone — connect a local agent before hunting"** and blocks the hunt, even though the server reports a live agent.

Repro: connect the 3 agents; the server's `/api/agents/local/status?check=1` reports e.g. `hermes.lastPing.ok = true`, yet `t3mpHasBackend()` returns `false` after any Settings detect/re-render.

## Root cause
The Settings agent card's `render()` sets `window.__t3mpLiveAgents` from **client-side pings only**:
```js
const live = Object.keys(pingStatus).filter(k => pingStatus[k].ok).length;
window.__t3mpLiveAgents = live;
```
Agents connected **server-side** — via `autoReconnect` (`ping:false`) or a `status?check=1` re-ping — are live on the server even though this client never pinged them. So `pingStatus` is empty and every re-render resets the count to `0`, clobbering the correct server-derived value.

Since `t3mpHasBackend()` is `llmAvailable || __t3mpLiveAgents > 0`, that clobber drops the backbone gate to `false` and the "connect an agent" nudge fires with a usable agent right there.

## Fix
Count live agents as the max of client pings **and** the server's own reported state (`window.__t3mpServerAgents`, refreshed via `status?check=1`), so a re-render never reports fewer live agents than the server knows about:
```js
const clientLive = Object.keys(pingStatus).filter(k => pingStatus[k].ok).length;
const serverLive = Array.isArray(window.__t3mpServerAgents)
  ? window.__t3mpServerAgents.filter(a => a.lastPing && a.lastPing.ok).length : 0;
const live = Math.max(clientLive, serverLive);
```
One hunk in `docs/index.html`; the summary line and the global both now reflect reality.

## Verified
`hasBackend` stays `true` across detect/connect re-renders; the nudge stays hidden; summary reads `3 active · 1 live · 3 ready · 3/3 installed`.