### PR TITLE
Tighten approval receipts and scope UI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3305,6 +3305,10 @@
                 <div class="nav-item active" data-page="warroom">
                     <span class="icon">⚔️</span> War Room
                 </div>
+                <div class="nav-item" data-page="receipts">
+                    <span class="icon">🧾</span> Scope Receipts
+                    <span class="badge" id="pendingReceiptCount">0</span>
+                </div>
                 <div class="nav-item" data-page="operators">
                     <span class="icon">🤖</span> Operatives
                     <span class="badge" id="activeOperatorCount">0</span>
@@ -4171,6 +4175,28 @@
 
                     <!-- Hidden compat elements -->
                     <div id="targetList" style="display: none;"></div>
+                </div>
+
+                <!-- Scope Receipts - explicit approvals for external/live execution -->
+                <div class="page" id="page-receipts">
+                    <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:18px;flex-wrap:wrap;">
+                        <div>
+                            <div style="font-size:10px;color:var(--accent);text-transform:uppercase;letter-spacing:2px;margin-bottom:6px;">ScopeGuard</div>
+                            <div style="font-size:24px;font-weight:800;color:var(--text-primary);line-height:1.15;">Scope Receipts</div>
+                        </div>
+                        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+                            <button class="btn btn-secondary btn-sm" onclick="refreshReceiptsPage()">Refresh</button>
+                            <button class="btn btn-secondary btn-sm" onclick="approveAllPendingReceipts()">Approve Pending</button>
+                        </div>
+                    </div>
+                    <div id="receiptsSummary" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin-bottom:14px;"></div>
+                    <section style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;overflow:hidden;">
+                        <div style="padding:12px 14px;border-bottom:1px solid var(--border-color);display:flex;justify-content:space-between;align-items:center;gap:10px;">
+                            <div style="font-size:11px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:1px;">Approval Requests</div>
+                            <div id="receiptsCount" style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--accent);">0 receipts</div>
+                        </div>
+                        <div id="receiptsList" style="max-height:min(62vh,680px);overflow:auto;"></div>
+                    </section>
                 </div>
 
                 <!-- Operators - Tactical Unit Command -->
@@ -6907,13 +6933,106 @@ Correlating findings across agents, identifying patterns, producing actionable i
             }));
         }
 
+        const ReceiptsState = { approvals: [] };
+
+        function receiptStatusColor(status) {
+            const s = String(status || '').toLowerCase();
+            if (s === 'approved') return '#00ff88';
+            if (s === 'pending') return '#ffaa00';
+            if (s === 'rejected' || s === 'expired') return '#ff6666';
+            return 'var(--text-secondary)';
+        }
+
+        window.refreshReceiptsPage = async function refreshReceiptsPage() {
+            const data = await T3MP3ST_API.get('/api/approvals');
+            ReceiptsState.approvals = Array.isArray(data.approvals) ? data.approvals : [];
+            renderReceiptsPage();
+        };
+
+        window.approveReceipt = async function approveReceipt(id) {
+            await T3MP3ST_API.post('/api/approvals/' + id + '/approve', {});
+            await window.refreshReceiptsPage();
+            if (window.toast) toast('Receipt approved: ' + id, 'success');
+        };
+
+        window.rejectReceipt = async function rejectReceipt(id) {
+            await T3MP3ST_API.post('/api/approvals/' + id + '/reject', {});
+            await window.refreshReceiptsPage();
+            if (window.toast) toast('Receipt rejected: ' + id, 'warning');
+        };
+
+        window.approveAllPendingReceipts = async function approveAllPendingReceipts() {
+            const pending = ReceiptsState.approvals.filter(function(a){ return a.status === 'pending'; });
+            await Promise.all(pending.map(function(a){ return T3MP3ST_API.post('/api/approvals/' + a.id + '/approve', {}); }));
+            await window.refreshReceiptsPage();
+            if (window.toast) toast('Approved ' + pending.length + ' pending receipt(s)', pending.length ? 'success' : 'info');
+        };
+
+        function renderReceiptsPage() {
+            const approvals = ReceiptsState.approvals || [];
+            const pending = approvals.filter(function(a){ return a.status === 'pending'; }).length;
+            const approved = approvals.filter(function(a){ return a.status === 'approved'; }).length;
+            const expired = approvals.filter(function(a){ return a.status === 'expired' || a.status === 'rejected'; }).length;
+            const badge = document.getElementById('pendingReceiptCount');
+            if (badge) {
+                badge.textContent = String(pending);
+                badge.style.background = pending ? '#ffaa00' : 'rgba(255,255,255,0.12)';
+                badge.style.color = pending ? '#1b1200' : '';
+            }
+            const summary = document.getElementById('receiptsSummary');
+            if (summary) {
+                const cells = [
+                    ['Pending', pending, pending ? '#ffaa00' : 'var(--text-secondary)'],
+                    ['Approved', approved, '#00ff88'],
+                    ['Closed', expired, expired ? '#ff6666' : 'var(--text-secondary)'],
+                    ['Total', approvals.length, '#00aaff']
+                ];
+                summary.innerHTML = cells.map(function(cell){
+                    return '<div style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;padding:12px;min-height:74px;">'
+                        + '<div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">' + escapeHtml(cell[0]) + '</div>'
+                        + '<div style="font-family:&quot;JetBrains Mono&quot;,monospace;font-size:18px;color:' + cell[2] + ';">' + escapeHtml(cell[1]) + '</div>'
+                        + '</div>';
+                }).join('');
+            }
+            const count = document.getElementById('receiptsCount');
+            if (count) count.textContent = approvals.length + ' receipts';
+            const list = document.getElementById('receiptsList');
+            if (!list) return;
+            if (!approvals.length) {
+                list.innerHTML = '<div style="padding:18px;color:var(--text-muted);font-size:12px;">No receipts yet. Live external actions will create target-scoped approval requests here.</div>';
+                return;
+            }
+            list.innerHTML = approvals.map(function(a){
+                const color = receiptStatusColor(a.status);
+                const pendingActions = a.status === 'pending'
+                    ? '<div style="display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap;"><button class="btn btn-primary btn-sm" onclick="approveReceipt(&quot;' + escapeHtml(a.id) + '&quot;)">Approve</button><button class="btn btn-secondary btn-sm" onclick="rejectReceipt(&quot;' + escapeHtml(a.id) + '&quot;)">Reject</button></div>'
+                    : '';
+                return '<div style="padding:12px 14px;border-bottom:1px solid rgba(255,255,255,0.06);display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;align-items:start;">'
+                    + '<div style="min-width:0;">'
+                    + '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:6px;"><span style="font-family:&quot;JetBrains Mono&quot;,monospace;font-size:10px;color:var(--text-muted);">' + escapeHtml(a.id) + '</span><span style="font-family:&quot;JetBrains Mono&quot;,monospace;font-size:10px;color:' + color + ';text-transform:uppercase;">' + escapeHtml(a.status || 'unknown') + '</span></div>'
+                    + '<div style="font-size:13px;color:var(--text-primary);font-weight:700;overflow-wrap:anywhere;">' + escapeHtml(a.target || '-') + '</div>'
+                    + '<div style="font-size:11px;color:var(--text-muted);margin-top:4px;">' + escapeHtml(a.action || '-') + ' · ' + escapeHtml(a.requestedBy || '-') + '</div>'
+                    + '<div style="font-size:11px;color:var(--text-secondary);margin-top:7px;line-height:1.45;overflow-wrap:anywhere;">' + escapeHtml(a.reason || '') + '</div>'
+                    + (a.expiresAt ? '<div style="font-size:10px;color:var(--text-muted);margin-top:7px;">Expires ' + escapeHtml(new Date(a.expiresAt).toLocaleString()) + '</div>' : '')
+                    + '</div>'
+                    + pendingActions
+                    + '</div>';
+            }).join('');
+        }
+
+        setInterval(() => {
+            if (document.getElementById('page-receipts')?.classList.contains('active')) {
+                window.refreshReceiptsPage?.();
+            }
+        }, 4000);
         // Navigation
         function navigateTo(page) {
             document.querySelectorAll('.nav-item').forEach(i => i.classList.toggle('active', i.dataset.page === page));
             document.querySelectorAll('.page').forEach(p => p.classList.toggle('active', p.id === `page-${page}`));
-            const titles = { warroom: 'War Room', operators: 'Operatives', evidence: 'Evidence Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
+            const titles = { warroom: 'War Room', receipts: 'Scope Receipts', operators: 'Operatives', evidence: 'Evidence Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
             document.getElementById('pageTitle').textContent = titles[page] || 'War Room';
             document.getElementById('sidebar').classList.remove('open');
+            if (page === 'receipts') setTimeout(() => window.refreshReceiptsPage?.(), 50);
             if (page === 'operators' && typeof window.loadOperativesRoster === 'function') setTimeout(window.loadOperativesRoster, 80);
             if (page === 'evidence' && typeof window.hydrateFindings === 'function') setTimeout(window.hydrateFindings, 60);
             if (page === 'selfimprove' && typeof window.renderSelfImprove === 'function') setTimeout(window.renderSelfImprove, 60);
@@ -25147,6 +25266,10 @@ Be specific and actionable. Format as structured JSON.`;
     if (typeof updateSitRep === 'function') updateSitRep('reconnaissance', '⚓ Op Admiral is planning the ' + t.label + ' operation on ' + tgt + '…', 'ACTIVE');
     if (typeof addIntel === 'function') addIntel('ADMIRAL', '⚓ Brief handed to Op Admiral — planning ' + brief.family + ' on ' + tgt + ' (~30-90s)', 'info');
     if (window.toast) toast('⚓ Op Admiral is planning the operation…', 'info');
+    const admiralApiBase = (typeof getApiBase === 'function')
+      ? getApiBase()
+      : ((typeof T3MP3ST_API !== 'undefined' && T3MP3ST_API.baseUrl) || '');
+    const admiralFetch = function(path, opts){ return fetch(admiralApiBase + path, opts); };
     const body = function(extra){ return JSON.stringify(Object.assign({ brief: brief, confirmed: true }, bb, extra || {})); };
     // Op Admiral planning is a slow LLM call, and on success the SERVER brings up a LIVE
     // mission. The server budgets up to 300s for planning, so the client cap MUST exceed that
@@ -25156,31 +25279,29 @@ Be specific and actionable. Format as structured JSON.`;
     // cautious rather than declaring failure.
     const launchOpts = function(extra){ return { method:'POST', headers:{'Content-Type':'application/json'}, body: body(extra), signal: AbortSignal.timeout(330000) }; };
     try {
-      let res = await fetch('/api/admiral/launch', launchOpts());
+      let approvalIds = [];
+      let res = await admiralFetch('/api/admiral/launch', launchOpts());
       let d = await res.json();
-      // autonomous-execution approval receipt — auto-grant for loopback/lab or Autonomous mode, else require it.
-      // The server gates this with HTTP 403 (blockForApproval); the HOLD gate below is 409.
-      if (res.status === 403 && d.approval && d.approval.id) {
-        if (isLab || autonomous) {
-          await fetch('/api/approvals/' + d.approval.id + '/approve', { method:'POST', headers:{'Content-Type':'application/json'}, body:'{}' });
-          res = await fetch('/api/admiral/launch', launchOpts({ approvalId: d.approval.id }));
-          d = await res.json();
-        } else {
-          throw new Error('Approval required for ' + tgt + ' — choose Autonomous mode, or approve in the receipts panel.');
+      for (let approvalRound = 0; approvalRound < 5 && res.status === 403; approvalRound++) {
+        const requested = [];
+        if (d.approval && d.approval.id) requested.push(d.approval);
+        if (Array.isArray(d.approvals)) d.approvals.forEach(function(a){ if (a && a.id) requested.push(a); });
+        if (!requested.length) break;
+        const requestedIds = requested.map(function(a){ return a.id; }).filter(Boolean);
+        const targets = (d.outOfScopeTargets || requested.map(function(a){ return a.target; }).filter(Boolean)).join(', ');
+        if (!(isLab || autonomous)) {
+          addIntel?.('SCOPEGUARD', 'Approval required: ' + (targets || tgt) + ' — open Scope Receipts', 'warning');
+          navigateTo?.('receipts');
+          throw new Error((d.error || 'Approval required') + ' — open Scope Receipts to approve ' + (targets || 'pending targets') + '.');
         }
-      }
-      if (res.status === 403 && Array.isArray(d.approvals) && d.approvals.length) {
-        const approvalIds = d.approvals.map(function(a){ return a && a.id; }).filter(Boolean);
-        const targets = (d.outOfScopeTargets || []).join(', ');
-        if (isLab || autonomous) {
-          await Promise.all(approvalIds.map(function(id){
-            return fetch('/api/approvals/' + id + '/approve', { method:'POST', headers:{'Content-Type':'application/json'}, body:'{}' });
-          }));
-          res = await fetch('/api/admiral/launch', launchOpts({ approvalIds: approvalIds }));
-          d = await res.json();
-        } else {
-          throw new Error('Expanded target approval required for ' + (targets || 'planner-added targets') + ' — approve the receipts or choose Autonomous mode.');
-        }
+        await Promise.all(requestedIds.map(function(id){
+          return admiralFetch('/api/approvals/' + id + '/approve', { method:'POST', headers:{'Content-Type':'application/json'}, body:'{}' });
+        }));
+        approvalIds = approvalIds.concat(requestedIds).filter(function(id, idx, arr){ return id && arr.indexOf(id) === idx; });
+        addIntel?.('SCOPEGUARD', 'Auto-approved ' + requestedIds.length + ' receipt(s): ' + (targets || requestedIds.join(', ')), 'success');
+        await window.refreshReceiptsPage?.();
+        res = await admiralFetch('/api/admiral/launch', launchOpts({ approvalIds: approvalIds }));
+        d = await res.json();
       }
       if (res.status === 409 && d.review && d.review.status === 'hold') throw new Error('Op Admiral plan gate is HOLD — ' + ((d.review && d.review.reason) || 'manual review required before execution'));
       if (!res.ok || d.error) throw new Error(d.error || ('launch failed (' + res.status + ')'));

--- a/docs/index.html
+++ b/docs/index.html
@@ -6950,9 +6950,13 @@ Correlating findings across agents, identifying patterns, producing actionable i
         };
 
         window.approveReceipt = async function approveReceipt(id) {
+            const receipt = ReceiptsState.approvals.find(function(a){ return a.id === id; });
             await T3MP3ST_API.post('/api/approvals/' + id + '/approve', {});
             await window.refreshReceiptsPage();
             if (window.toast) toast('Receipt approved: ' + id, 'success');
+            if (receipt?.action === 'autonomous_execution' && window.__t3mpAdmiralPendingRetry && typeof window.retryPendingAdmiralLaunch === 'function') {
+                window.retryPendingAdmiralLaunch();
+            }
         };
 
         window.rejectReceipt = async function rejectReceipt(id) {
@@ -6966,6 +6970,9 @@ Correlating findings across agents, identifying patterns, producing actionable i
             await Promise.all(pending.map(function(a){ return T3MP3ST_API.post('/api/approvals/' + a.id + '/approve', {}); }));
             await window.refreshReceiptsPage();
             if (window.toast) toast('Approved ' + pending.length + ' pending receipt(s)', pending.length ? 'success' : 'info');
+            if (pending.some(function(a){ return a.action === 'autonomous_execution'; }) && window.__t3mpAdmiralPendingRetry && typeof window.retryPendingAdmiralLaunch === 'function') {
+                window.retryPendingAdmiralLaunch();
+            }
         };
 
         function renderReceiptsPage() {
@@ -25266,6 +25273,14 @@ Be specific and actionable. Format as structured JSON.`;
     if (typeof updateSitRep === 'function') updateSitRep('reconnaissance', '⚓ Op Admiral is planning the ' + t.label + ' operation on ' + tgt + '…', 'ACTIVE');
     if (typeof addIntel === 'function') addIntel('ADMIRAL', '⚓ Brief handed to Op Admiral — planning ' + brief.family + ' on ' + tgt + ' (~30-90s)', 'info');
     if (window.toast) toast('⚓ Op Admiral is planning the operation…', 'info');
+    window.__t3mpAdmiralPendingRetry = false;
+    window.retryPendingAdmiralLaunch = function(){
+      if (!window.__t3mpAdmiralPendingRetry) return;
+      window.__t3mpAdmiralPendingRetry = false;
+      if (typeof addIntel === 'function') addIntel('SCOPEGUARD', 'Receipt approved — retrying Admiral launch', 'info');
+      if (window.toast) toast('Receipt approved — retrying Admiral launch', 'info');
+      setTimeout(function(){ window.admiralLaunch(); }, 50);
+    };
     const admiralApiBase = (typeof getApiBase === 'function')
       ? getApiBase()
       : ((typeof T3MP3ST_API !== 'undefined' && T3MP3ST_API.baseUrl) || '');
@@ -25290,9 +25305,10 @@ Be specific and actionable. Format as structured JSON.`;
         const requestedIds = requested.map(function(a){ return a.id; }).filter(Boolean);
         const targets = (d.outOfScopeTargets || requested.map(function(a){ return a.target; }).filter(Boolean)).join(', ');
         if (!(isLab || autonomous)) {
+          window.__t3mpAdmiralPendingRetry = true;
           addIntel?.('SCOPEGUARD', 'Approval required: ' + (targets || tgt) + ' — open Scope Receipts', 'warning');
           navigateTo?.('receipts');
-          throw new Error((d.error || 'Approval required') + ' — open Scope Receipts to approve ' + (targets || 'pending targets') + '.');
+          throw new Error((d.error || 'Approval required') + ' — approve ' + (targets || 'pending targets') + ' in Scope Receipts; launch will retry after approval.');
         }
         await Promise.all(requestedIds.map(function(id){
           return admiralFetch('/api/approvals/' + id + '/approve', { method:'POST', headers:{'Content-Type':'application/json'}, body:'{}' });

--- a/docs/index.html
+++ b/docs/index.html
@@ -3666,6 +3666,10 @@
                                 <div id="spicyWarnStrip" style="display:none;padding:7px 9px;background:rgba(255,68,68,0.10);border-left:3px solid #ff4444;border-radius:4px;margin-bottom:8px;font-size:11px;color:#ff8a8a;"></div>
                                 <div id="approvalAuditFeed" style="max-height:180px;overflow-y:auto;font-family:'JetBrains Mono',monospace;font-size:10px;line-height:1.55;"><span style="color:#5a5f67;font-size:10.5px;">Waiting for gated tool calls…</span></div>
                             </section>
+                            <section class="hunt-panel">
+                                <div class="ops-card-title"><span>Scope Receipts</span><span id="scopeReceiptCount">0 pending</span></div>
+                                <div id="scopeReceiptFeed" style="max-height:180px;overflow-y:auto;font-family:'JetBrains Mono',monospace;font-size:10px;line-height:1.55;"><span style="color:#5a5f67;font-size:10.5px;">No pending scope receipts.</span></div>
+                            </section>
                         </div>
                         <div class="hunt-pulse-board" id="zeroDayHuntPulse">
                             <section class="hunt-panel">
@@ -5916,11 +5920,17 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                     this._eventSource.addEventListener('connected', () => {
                         console.log('[BackendDispatch] SSE connected');
                         try { fetchToolApprovals(); } catch {}
+                        try { fetchScopeReceipts(); } catch {}
                     });
 
                     // Capability-approval gate: every gated tool decision (allow/deny) + spicy warning.
                     this._eventSource.addEventListener('arsenal.approval', (e) => {
                         try { pushApprovalAuditEvent(JSON.parse(e.data)); } catch {}
+                    });
+                    ['approval.requested', 'approval.approved', 'approval.rejected'].forEach((eventName) => {
+                        this._eventSource.addEventListener(eventName, () => {
+                            try { fetchScopeReceipts(); } catch {}
+                        });
                     });
 
                     this._eventSource.addEventListener('operator:spawned', (e) => {
@@ -24399,6 +24409,55 @@ Be specific and actionable. Format as structured JSON.`;
                 if (data.audit.length) { feed.dataset.live = '1'; feed.innerHTML = ''; data.audit.slice(-40).forEach(rec => pushApprovalAuditEvent(rec, true)); }
             }
         }
+        async function fetchScopeReceipts() {
+            try {
+                if (!T3MP3ST_API.baseUrl) return;
+                const r = await fetch(`${T3MP3ST_API.baseUrl}/api/approvals`);
+                if (!r.ok) return;
+                const data = await r.json();
+                renderScopeReceipts((data && data.approvals) || []);
+            } catch (e) { /* offline — panel stays in its last known state */ }
+        }
+        function renderScopeReceipts(approvals) {
+            const feed = document.getElementById('scopeReceiptFeed');
+            const count = document.getElementById('scopeReceiptCount');
+            if (!feed) return;
+            const pending = (approvals || []).filter(a => a && a.status === 'pending');
+            const recent = (approvals || []).slice().sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || ''))).slice(0, 12);
+            if (count) count.textContent = `${pending.length} pending`;
+            if (!recent.length) {
+                feed.innerHTML = '<span style="color:#5a5f67;font-size:10.5px;">No scope receipts yet.</span>';
+                return;
+            }
+            feed.innerHTML = recent.map(a => {
+                const status = String(a.status || 'pending');
+                const color = status === 'approved' ? '#00ff88' : status === 'rejected' ? '#ff6b6b' : status === 'expired' ? '#888' : '#ffaa00';
+                const expires = a.expiresAt ? ` · expires ${escapeHtml(new Date(a.expiresAt).toLocaleTimeString())}` : '';
+                const controls = status === 'pending'
+                    ? `<button onclick="approveScopeReceipt('${escapeHtml(a.id)}')" style="margin-left:6px;padding:2px 6px;border:1px solid rgba(0,255,136,0.4);background:rgba(0,255,136,0.08);color:#00ff88;border-radius:4px;font-size:10px;">Approve</button><button onclick="rejectScopeReceipt('${escapeHtml(a.id)}')" style="margin-left:4px;padding:2px 6px;border:1px solid rgba(255,107,107,0.4);background:rgba(255,107,107,0.08);color:#ff6b6b;border-radius:4px;font-size:10px;">Reject</button>`
+                    : '';
+                return `<div style="padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.05);color:${color};"><b>${escapeHtml(status.toUpperCase())}</b> <span style="color:#aaa;">${escapeHtml(a.action || '')}</span> → ${escapeHtml(a.target || '')}<br><span style="color:#666;">${escapeHtml(a.id || '')}${expires}</span>${controls}</div>`;
+            }).join('');
+            setOpsReady('approval', pending.length ? 'block' : 'ok', pending.length ? `${pending.length} pending` : 'receipts ok');
+        }
+        window.approveScopeReceipt = async function(id) {
+            try {
+                await T3MP3ST_API.post(`/api/approvals/${id}/approve`, { approvedBy: 'local-operator' });
+                try { addIntel('SCOPEGUARD', `Approved receipt ${id}`, 'success'); } catch (e) {}
+                await fetchScopeReceipts();
+            } catch (e) {
+                try { toast('Receipt approval failed', 'error'); } catch (err) {}
+            }
+        };
+        window.rejectScopeReceipt = async function(id) {
+            try {
+                await T3MP3ST_API.post(`/api/approvals/${id}/reject`, {});
+                try { addIntel('SCOPEGUARD', `Rejected receipt ${id}`, 'warning'); } catch (e) {}
+                await fetchScopeReceipts();
+            } catch (e) {
+                try { toast('Receipt rejection failed', 'error'); } catch (err) {}
+            }
+        };
         function pushApprovalAuditEvent(rec, silent) {
             const feed = document.getElementById('approvalAuditFeed');
             if (!feed || !rec) return;
@@ -24442,6 +24501,7 @@ Be specific and actionable. Format as structured JSON.`;
                 try { addMissionLog('info', `Approval receipt requested: ${approval.id}`); } catch (e) {}
                 try { addIntel('SCOPEGUARD', `Receipt ${approval.id} is ${approval.status}`, 'info'); } catch (e) {}
                 try { toast(`Receipt requested: ${approval.id}`, 'success'); } catch (e) {}
+                try { fetchScopeReceipts(); } catch (e) {}
             } catch (e) {
                 setOpsReady('approval', 'block', 'request failed');
                 try { addMissionLog('warning', `Approval receipt failed: ${e.message || e}`); } catch (err) {}

--- a/docs/index.html
+++ b/docs/index.html
@@ -25169,6 +25169,19 @@ Be specific and actionable. Format as structured JSON.`;
           throw new Error('Approval required for ' + tgt + ' — choose Autonomous mode, or approve in the receipts panel.');
         }
       }
+      if (res.status === 403 && Array.isArray(d.approvals) && d.approvals.length) {
+        const approvalIds = d.approvals.map(function(a){ return a && a.id; }).filter(Boolean);
+        const targets = (d.outOfScopeTargets || []).join(', ');
+        if (isLab || autonomous) {
+          await Promise.all(approvalIds.map(function(id){
+            return fetch('/api/approvals/' + id + '/approve', { method:'POST', headers:{'Content-Type':'application/json'}, body:'{}' });
+          }));
+          res = await fetch('/api/admiral/launch', launchOpts({ approvalIds: approvalIds }));
+          d = await res.json();
+        } else {
+          throw new Error('Expanded target approval required for ' + (targets || 'planner-added targets') + ' — approve the receipts or choose Autonomous mode.');
+        }
+      }
       if (res.status === 409 && d.review && d.review.status === 'hold') throw new Error('Op Admiral plan gate is HOLD — ' + ((d.review && d.review.reason) || 'manual review required before execution'));
       if (!res.ok || d.error) throw new Error(d.error || ('launch failed (' + res.status + ')'));
       const nOps = (d.operators || []).length;

--- a/src/__tests__/local-api-hardening-static.test.ts
+++ b/src/__tests__/local-api-hardening-static.test.ts
@@ -50,4 +50,17 @@ describe('local API authorization hardening invariants', () => {
     expect(serverSource).toMatch(/Wildcard host approval requires explicit opt-in/);
     expect(serverSource).toMatch(/body\.allowWildcard !== true/);
   });
+
+  it('authorize-target only approves existing pending receipts and cannot mint broad active-action approvals', () => {
+    const route = routeBlock("app.post('/api/approvals/authorize-target'", "app.post('/api/approvals/:id/reject'");
+
+    expect(route).toMatch(/approvalId/);
+    expect(route).toMatch(/approvalIds/);
+    expect(route).toMatch(/approvalRequests\.get\(id\)/);
+    expect(route).toMatch(/approval\.status !== 'pending'/);
+    expect(route).toMatch(/Math\.min\(30/);
+    expect(route).not.toMatch(/createApprovalRequest/);
+    expect(route).not.toMatch(/allowedActions/);
+    expect(route).not.toMatch(/command_execution['"],\s*['"]autonomous_execution/);
+  });
 });

--- a/src/__tests__/local-api-hardening-static.test.ts
+++ b/src/__tests__/local-api-hardening-static.test.ts
@@ -30,7 +30,7 @@ describe('local API authorization hardening invariants', () => {
     expect(route).toMatch(/guardAction\(body,\s*['"]command_execution['"],\s*targetResolution\.target/);
   });
 
-  it('Admiral live launch re-checks every General-produced execution target before mission bring-up', () => {
+  it('Admiral live launch permits expanded targets only with explicit operator approval receipts', () => {
     const route = routeBlock("app.post('/api/admiral/launch'", '// =============================================================================\n// BOUNTY PLATFORM INTEGRATIONS');
 
     expect(route).toMatch(/ensureExecTargetsAuthorized\(execConfig\.targets,\s*brief\.target,\s*req\.body/);
@@ -38,5 +38,16 @@ describe('local API authorization hardening invariants', () => {
     expect(route.indexOf('ensureExecTargetsAuthorized(execConfig.targets, brief.target'))
       .toBeLessThan(route.indexOf('bringUpMissionFromPlan(execConfig, generalConfig)'));
     expect(route).toMatch(/approvals/);
+    expect(route).toMatch(/approvalIds/);
+  });
+
+  it('approval lookup requires explicit receipt ids and wildcard hosts require opt-in', () => {
+    const findApproval = routeBlock('function findApproval(', 'function createApprovalRequest');
+
+    expect(findApproval).toMatch(/body\.approvalId/);
+    expect(findApproval).toMatch(/body\.approvalIds/);
+    expect(findApproval).not.toMatch(/\[\.\.\.approvalRequests\.values\(\)\]/);
+    expect(serverSource).toMatch(/Wildcard host approval requires explicit opt-in/);
+    expect(serverSource).toMatch(/body\.allowWildcard !== true/);
   });
 });

--- a/src/__tests__/local-api-hardening-static.test.ts
+++ b/src/__tests__/local-api-hardening-static.test.ts
@@ -33,9 +33,10 @@ describe('local API authorization hardening invariants', () => {
   it('Admiral live launch re-checks every General-produced execution target before mission bring-up', () => {
     const route = routeBlock("app.post('/api/admiral/launch'", '// =============================================================================\n// BOUNTY PLATFORM INTEGRATIONS');
 
-    expect(route).toMatch(/ensureExecTargetsWithinApprovedTarget\(execConfig\.targets, brief\.target\)/);
+    expect(route).toMatch(/ensureExecTargetsAuthorized\(execConfig\.targets,\s*brief\.target,\s*req\.body/);
     expect(route).toMatch(/outOfScopeTargets\.length/);
-    expect(route.indexOf('ensureExecTargetsWithinApprovedTarget(execConfig.targets, brief.target)'))
+    expect(route.indexOf('ensureExecTargetsAuthorized(execConfig.targets, brief.target'))
       .toBeLessThan(route.indexOf('bringUpMissionFromPlan(execConfig, generalConfig)'));
+    expect(route).toMatch(/approvals/);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1094,7 +1094,13 @@ function approvalIsFresh(approval: ApprovalRequest): boolean {
 function approvalMatches(approval: ApprovalRequest, action: GuardAction, target: string): boolean {
   if (approval.action !== action) return false;
   if (approval.target === '*') return action === 'model_call' || action === 'autonomous_execution';
-  return hostFromTarget(approval.target) === hostFromTarget(target);
+  const approvalHost = hostFromTarget(approval.target);
+  const targetHost = hostFromTarget(target);
+  if (approvalHost.startsWith('*.')) {
+    const suffix = approvalHost.slice(1);
+    return targetHost.endsWith(suffix) && targetHost !== approvalHost.slice(2);
+  }
+  return approvalHost === targetHost;
 }
 
 function ensureExecTargetsWithinApprovedTarget(targets: string[], approvedTarget: string): string[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1111,10 +1111,19 @@ function approvalMatchesGateScope(approval: ApprovalRequest, action: GuardAction
 }
 
 function findApproval(body: Record<string, unknown>, action: GuardAction, target: string): ApprovalRequest | null {
-  const id = typeof body.approvalId === 'string' ? body.approvalId : '';
-  const approval = id ? approvalRequests.get(id) : undefined;
-  if (!approval || !approvalIsFresh(approval) || !approvalMatches(approval, action, target)) return null;
-  return approval;
+  const ids = [
+    typeof body.approvalId === 'string' ? body.approvalId : '',
+    ...(Array.isArray(body.approvalIds) ? body.approvalIds.filter((id): id is string => typeof id === 'string') : []),
+  ].filter(Boolean);
+
+  for (const id of ids) {
+    const approval = approvalRequests.get(id);
+    if (approval && approvalIsFresh(approval) && approvalMatches(approval, action, target)) return approval;
+  }
+
+  return [...approvalRequests.values()]
+    .filter(approval => approvalIsFresh(approval) && approvalMatches(approval, action, target))
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0] || null;
 }
 
 function createApprovalRequest(action: GuardAction, target: string, reason: string, body: Record<string, unknown>): ApprovalRequest {
@@ -4825,6 +4834,52 @@ app.post('/api/approvals/:id/approve', (req: Request, res: Response) => {
   res.json(approval);
 });
 
+app.post('/api/approvals/authorize-target', (req: Request, res: Response) => {
+  const body = req.body as Record<string, unknown>;
+  const target = normalizeTargetValue(body.target);
+  if (!target) {
+    res.status(400).json({ error: 'target required' });
+    return;
+  }
+  if (target === '*') {
+    res.status(400).json({
+      error: 'Wildcard target authorization is not allowed for active actions',
+      next: 'Authorize one concrete host or URL so receipts remain target-scoped.',
+    });
+    return;
+  }
+
+  const requestedActions = Array.isArray(body.actions) ? body.actions.map(String) : [];
+  const allowedActions: GuardAction[] = ['mission_execution', 'network_request', 'command_execution', 'autonomous_execution'];
+  const actions = (requestedActions.length ? requestedActions : allowedActions)
+    .filter((action): action is GuardAction => allowedActions.includes(action as GuardAction));
+  if (!actions.length) {
+    res.status(400).json({ error: 'No supported approval actions requested' });
+    return;
+  }
+
+  const ttlMinutes = Number(body.ttlMinutes || process.env.T3MP3ST_APPROVAL_TTL_MINUTES || 240);
+  const expiresAt = new Date(Date.now() + Math.max(1, ttlMinutes) * 60_000).toISOString();
+  const approvals = actions.map((action) => {
+    const approval = createApprovalRequest(
+      action,
+      target,
+      typeof body.reason === 'string' && body.reason.trim()
+        ? body.reason.trim()
+        : `Authorize ${action} against ${target}`,
+      body
+    );
+    approval.status = 'approved';
+    approval.approvedBy = typeof body.approvedBy === 'string' ? body.approvedBy : 'local-operator';
+    approval.expiresAt = expiresAt;
+    approval.updatedAt = nowIso();
+    emitContractEvent('approval.approved', { approvalId: approval.id, action: approval.action, target: approval.target });
+    return approval;
+  });
+
+  res.status(201).json({ target, expiresAt, approvals });
+});
+
 app.post('/api/approvals/:id/reject', (req: Request, res: Response) => {
   const approval = approvalRequests.get(req.params.id);
   if (!approval) {
@@ -5999,6 +6054,14 @@ app.post('/api/mission/start', async (req: Request, res: Response): Promise<void
     const targetValue = normalizeTargetValue(target);
     const guard = guardAction(req.body as Record<string, unknown>, 'mission_execution', targetValue, `Start mission ${name} against ${targetValue}`);
     if (!guard.allowed) { blockForApproval(res, guard); return; }
+  }
+
+  if (provider === 'local-agent') {
+    const localAgent = await requireLiveLocalAgent(model);
+    if (!localAgent.ok) {
+      res.status(503).json({ error: localAgent.error });
+      return;
+    }
   }
 
   // B-03: if an OPTIONAL white-box repoPath was supplied, containment-check it HERE

--- a/src/server.ts
+++ b/src/server.ts
@@ -4874,8 +4874,15 @@ app.post('/api/approvals/:id/approve', (req: Request, res: Response) => {
 app.post('/api/approvals/authorize-target', (req: Request, res: Response) => {
   const body = req.body as Record<string, unknown>;
   const target = normalizeTargetValue(body.target);
-  if (!target) {
-    res.status(400).json({ error: 'target required' });
+  const approvalIds = [
+    typeof body.approvalId === 'string' ? body.approvalId : '',
+    ...(Array.isArray(body.approvalIds) ? body.approvalIds.filter((id): id is string => typeof id === 'string') : []),
+  ].filter(Boolean);
+  if (!approvalIds.length) {
+    res.status(400).json({
+      error: 'approvalId or approvalIds required',
+      next: 'Request a pending receipt first, then approve that exact receipt id.',
+    });
     return;
   }
   if (target === '*') {
@@ -4893,35 +4900,37 @@ app.post('/api/approvals/authorize-target', (req: Request, res: Response) => {
     return;
   }
 
-  const requestedActions = Array.isArray(body.actions) ? body.actions.map(String) : [];
-  const allowedActions: GuardAction[] = ['mission_execution', 'network_request', 'command_execution', 'autonomous_execution'];
-  const actions = (requestedActions.length ? requestedActions : allowedActions)
-    .filter((action): action is GuardAction => allowedActions.includes(action as GuardAction));
-  if (!actions.length) {
-    res.status(400).json({ error: 'No supported approval actions requested' });
-    return;
-  }
-
-  const ttlMinutes = Number(body.ttlMinutes || process.env.T3MP3ST_APPROVAL_TTL_MINUTES || 240);
-  const expiresAt = new Date(Date.now() + Math.max(1, ttlMinutes) * 60_000).toISOString();
-  const approvals = actions.map((action) => {
-    const approval = createApprovalRequest(
-      action,
-      target,
-      typeof body.reason === 'string' && body.reason.trim()
-        ? body.reason.trim()
-        : `Authorize ${action} against ${target}`,
-      body
-    );
+  const ttlMinutes = Math.max(1, Math.min(30, Number(body.ttlMinutes || 30)));
+  const expiresAt = new Date(Date.now() + ttlMinutes * 60_000).toISOString();
+  const approvals: ApprovalRequest[] = [];
+  for (const id of [...new Set(approvalIds)]) {
+    const approval = approvalRequests.get(id);
+    if (!approval) {
+      res.status(404).json({ error: 'Approval request not found', approvalId: id });
+      return;
+    }
+    if (approval.status !== 'pending') {
+      res.status(409).json({ error: 'Approval request is not pending', approvalId: id, status: approval.status });
+      return;
+    }
+    if (target && !approvalMatches(approval, approval.action, target)) {
+      res.status(400).json({
+        error: 'Approval target mismatch',
+        approvalId: id,
+        approvalTarget: approval.target,
+        target,
+      });
+      return;
+    }
     approval.status = 'approved';
     approval.approvedBy = typeof body.approvedBy === 'string' ? body.approvedBy : 'local-operator';
     approval.expiresAt = expiresAt;
     approval.updatedAt = nowIso();
     emitContractEvent('approval.approved', { approvalId: approval.id, action: approval.action, target: approval.target });
-    return approval;
-  });
+    approvals.push(approval);
+  }
 
-  res.status(201).json({ target, expiresAt, approvals });
+  res.json({ target: target || null, expiresAt, approvals });
 });
 
 app.post('/api/approvals/:id/reject', (req: Request, res: Response) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -507,6 +507,7 @@ interface ApprovalRequest {
   target: string;
   reason: string;
   status: ApprovalStatus;
+  wildcardOptIn?: boolean;
   operationId?: string;
   requestedBy: DraftSource | 'system';
   createdAt: string;
@@ -1091,10 +1092,23 @@ function approvalIsFresh(approval: ApprovalRequest): boolean {
   return Date.parse(approval.expiresAt) > Date.now();
 }
 
+function targetUsesWildcard(target: string): boolean {
+  const raw = normalizeTargetValue(target).toLowerCase();
+  if (raw === '*') return true;
+  const withoutScheme = raw.replace(/^[a-z][a-z0-9+.-]*:\/\//, '');
+  return withoutScheme.startsWith('*.') || hostFromTarget(raw).startsWith('*.');
+}
+
+function wildcardHostFromTarget(target: string): string {
+  const raw = normalizeTargetValue(target).toLowerCase().replace(/^[a-z][a-z0-9+.-]*:\/\//, '');
+  return raw.replace(/\/.*$/, '').replace(/:\d+$/, '');
+}
+
 function approvalMatches(approval: ApprovalRequest, action: GuardAction, target: string): boolean {
   if (approval.action !== action) return false;
+  if (targetUsesWildcard(approval.target) && !approval.wildcardOptIn) return false;
   if (approval.target === '*') return action === 'model_call' || action === 'autonomous_execution';
-  const approvalHost = hostFromTarget(approval.target);
+  const approvalHost = targetUsesWildcard(approval.target) ? wildcardHostFromTarget(approval.target) : hostFromTarget(approval.target);
   const targetHost = hostFromTarget(target);
   if (approvalHost.startsWith('*.')) {
     const suffix = approvalHost.slice(1);
@@ -1136,9 +1150,7 @@ function findApproval(body: Record<string, unknown>, action: GuardAction, target
     if (approval && approvalIsFresh(approval) && approvalMatches(approval, action, target)) return approval;
   }
 
-  return [...approvalRequests.values()]
-    .filter(approval => approvalIsFresh(approval) && approvalMatches(approval, action, target))
-    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0] || null;
+  return null;
 }
 
 function createApprovalRequest(action: GuardAction, target: string, reason: string, body: Record<string, unknown>): ApprovalRequest {
@@ -1149,6 +1161,7 @@ function createApprovalRequest(action: GuardAction, target: string, reason: stri
     target,
     reason,
     status: 'pending',
+    wildcardOptIn: body.allowWildcard === true && targetUsesWildcard(target),
     operationId: typeof operationDraft?.operation_id === 'string' ? operationDraft.operation_id : undefined,
     requestedBy: ['human', 'agent', 't3mp3st'].includes(String(body.source)) ? body.source as DraftSource : 'system',
     createdAt: nowIso(),
@@ -4826,6 +4839,15 @@ app.post('/api/approvals/request', (req: Request, res: Response) => {
     });
     return;
   }
+  if (targetUsesWildcard(target) && target !== '*' && body.allowWildcard !== true) {
+    res.status(400).json({
+      error: 'Wildcard host approval requires explicit opt-in',
+      action,
+      target,
+      next: 'Send allowWildcard:true only when the operator intentionally approves the whole subdomain wildcard.',
+    });
+    return;
+  }
   const reason = typeof body.reason === 'string' && body.reason.trim()
     ? body.reason.trim()
     : `Approval requested for ${action} against ${target}`;
@@ -4860,6 +4882,13 @@ app.post('/api/approvals/authorize-target', (req: Request, res: Response) => {
     res.status(400).json({
       error: 'Wildcard target authorization is not allowed for active actions',
       next: 'Authorize one concrete host or URL so receipts remain target-scoped.',
+    });
+    return;
+  }
+  if (targetUsesWildcard(target) && target !== '*' && body.allowWildcard !== true) {
+    res.status(400).json({
+      error: 'Wildcard host authorization requires explicit opt-in',
+      next: 'Send allowWildcard:true only when the operator intentionally approves the whole subdomain wildcard.',
     });
     return;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1104,6 +1104,15 @@ function ensureExecTargetsWithinApprovedTarget(targets: string[], approvedTarget
     .filter(target => hostFromTarget(target) !== approvedHost);
 }
 
+function ensureExecTargetsAuthorized(
+  targets: string[],
+  approvedTarget: string,
+  body: Record<string, unknown>,
+): string[] {
+  return ensureExecTargetsWithinApprovedTarget(targets, approvedTarget)
+    .filter(target => !findApproval(body, 'autonomous_execution', target));
+}
+
 function approvalMatchesGateScope(approval: ApprovalRequest, action: GuardAction, operationId: string, target: string): boolean {
   if (!approvalMatches(approval, action, target)) return false;
   if (approval.operationId && operationId && approval.operationId !== operationId) return false;
@@ -7326,12 +7335,20 @@ app.post('/api/admiral/launch', async (req: Request, res: Response): Promise<voi
       res.status(409).json({ error: 'General plan gate is HOLD', mode: 'live', plan, review: execConfig.review });
       return;
     }
-    const outOfScopeTargets = ensureExecTargetsWithinApprovedTarget(execConfig.targets, brief.target);
+    const outOfScopeTargets = ensureExecTargetsAuthorized(execConfig.targets, brief.target, req.body as Record<string, unknown>);
     if (outOfScopeTargets.length) {
+      const approvals = outOfScopeTargets.map(target => createApprovalRequest(
+        'autonomous_execution',
+        target,
+        `Admiral plan expanded execution scope from ${brief.target} to ${target}`,
+        req.body as Record<string, unknown>
+      ));
       res.status(403).json({
-        error: 'Admiral LIVE plan contains targets outside the approved brief target',
+        error: 'Admiral LIVE plan needs approval for expanded target scope',
         approvedTarget: brief.target,
         outOfScopeTargets,
+        approvals,
+        next: 'Approve the expanded target receipts, then retry /api/admiral/launch with approvalIds.',
       });
       return;
     }


### PR DESCRIPTION
## Summary
- Reuse target-scoped approval receipts through explicit approvalId/approvalIds only
- Add visible Scope Receipts UI with approve/reject controls for pending receipts
- Require wildcard host approvals to opt in explicitly
- Narrow /api/approvals/authorize-target so it only approves existing pending receipt IDs and cannot mint broad active-action approvals
- Retry Admiral expanded-scope launches with exact approvalIds after operator approval

## Validation
- HOME=/Users/threlfall/Documents/t3mp3st/.home npm run build
- HOME=/Users/threlfall/Documents/t3mp3st/.home npm test
