### PR TITLE
Add live scan progress and recon bootstrap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7131,13 +7131,16 @@ Correlating findings across agents, identifying patterns, producing actionable i
                             : ev.kind === 'tool_result' ? '#00aaff'
                             : ev.kind === 'thinking' ? '#cfd6e6'
                             : '#00ff88';
+                        const sourceBadge = ev.source === 'backend_seeded'
+                            ? '<span style="display:inline-block;margin-left:6px;padding:1px 5px;border:1px solid rgba(255,170,0,0.45);border-radius:3px;color:#ffaa00;font-size:9px;text-transform:uppercase;letter-spacing:0.4px;">backend-seeded</span>'
+                            : '';
                         return `
                             <div style="padding:10px 14px;border-bottom:1px solid rgba(255,255,255,0.055);display:grid;grid-template-columns:76px 74px minmax(110px,180px) minmax(0,1fr);gap:10px;align-items:start;">
                                 <div style="font-size:10px;color:var(--text-muted);">${liveScanTime(ev.timestamp)}</div>
                                 <div style="font-size:10px;color:${color};font-weight:800;">${liveScanEscape(liveScanKindLabel(ev.kind))}</div>
                                 <div style="font-size:10px;color:var(--accent);overflow-wrap:anywhere;">${liveScanEscape(ev.callsign || ev.archetype || ev.operatorId || '-')}</div>
                                 <div style="min-width:0;">
-                                    <div style="font-size:11px;color:var(--text-secondary);margin-bottom:4px;overflow-wrap:anywhere;">${liveScanEscape(ev.taskName || ev.toolName || '-')}</div>
+                                    <div style="font-size:11px;color:var(--text-secondary);margin-bottom:4px;overflow-wrap:anywhere;">${liveScanEscape(ev.taskName || ev.toolName || '-')}${sourceBadge}</div>
                                     <div style="font-size:12px;color:var(--text-primary);line-height:1.45;white-space:pre-wrap;overflow-wrap:anywhere;">${liveScanEscape(ev.detail || '')}</div>
                                 </div>
                             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,6 +295,11 @@
 
         .page { display: none; }
         .page.active { display: block; animation: fadeIn 0.3s ease; }
+        .live-scan-grid { display: grid; grid-template-columns: minmax(260px, 0.9fr) minmax(360px, 1.4fr); gap: 14px; align-items: start; }
+
+        @media (max-width: 900px) {
+            .live-scan-grid { grid-template-columns: 1fr; }
+        }
 
         @keyframes fadeIn {
             from { opacity: 0; transform: translateY(10px); }
@@ -3305,6 +3310,9 @@
                 <div class="nav-item active" data-page="warroom">
                     <span class="icon">⚔️</span> War Room
                 </div>
+                <div class="nav-item" data-page="live-scan">
+                    <span class="icon">📡</span> Live Scan
+                </div>
                 <div class="nav-item" data-page="operators">
                     <span class="icon">🤖</span> Operatives
                     <span class="badge" id="activeOperatorCount">0</span>
@@ -4171,6 +4179,48 @@
 
                     <!-- Hidden compat elements -->
                     <div id="targetList" style="display: none;"></div>
+                </div>
+
+                <!-- Live Scan - per-agent execution progress -->
+                <div class="page" id="page-live-scan">
+                    <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:18px;flex-wrap:wrap;">
+                        <div>
+                            <div style="font-size:10px;color:var(--accent);text-transform:uppercase;letter-spacing:2px;margin-bottom:6px;">Live Scan</div>
+                            <div style="font-size:24px;font-weight:800;color:var(--text-primary);line-height:1.15;">Agent Progress</div>
+                        </div>
+                        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+                            <button class="btn btn-secondary btn-sm" onclick="refreshLiveScanPage()">Refresh</button>
+                            <button class="btn btn-secondary btn-sm" onclick="clearLiveScanFeed()">Clear Feed</button>
+                        </div>
+                    </div>
+
+                    <div id="liveScanSummary" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin-bottom:14px;"></div>
+
+                    <div class="live-scan-grid">
+                        <section style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;overflow:hidden;">
+                            <div style="padding:12px 14px;border-bottom:1px solid var(--border-color);display:flex;justify-content:space-between;align-items:center;gap:10px;">
+                                <div style="font-size:11px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:1px;">Operators</div>
+                                <div id="liveScanOperatorCount" style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--accent);">0 active</div>
+                            </div>
+                            <div id="liveScanOperators" style="max-height:360px;overflow:auto;"></div>
+                        </section>
+
+                        <section style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;overflow:hidden;">
+                            <div style="padding:12px 14px;border-bottom:1px solid var(--border-color);display:flex;justify-content:space-between;align-items:center;gap:10px;">
+                                <div style="font-size:11px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:1px;">Task Queue</div>
+                                <div id="liveScanTaskCount" style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--accent);">0 tasks</div>
+                            </div>
+                            <div id="liveScanTasks" style="max-height:360px;overflow:auto;"></div>
+                        </section>
+                    </div>
+
+                    <section style="margin-top:14px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;overflow:hidden;">
+                        <div style="padding:12px 14px;border-bottom:1px solid var(--border-color);display:flex;justify-content:space-between;align-items:center;gap:10px;">
+                            <div style="font-size:11px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:1px;">Reasoning And Tool Stream</div>
+                            <div id="liveScanFeedCount" style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--accent);">0 events</div>
+                        </div>
+                        <div id="liveScanFeed" style="height:min(48vh,520px);min-height:300px;overflow:auto;font-family:'JetBrains Mono',monospace;background:rgba(0,0,0,0.18);"></div>
+                    </section>
                 </div>
 
                 <!-- Operators - Tactical Unit Command -->
@@ -5979,6 +6029,14 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                             if (data.operators) {
                                 this._updateOperatorStatusUI(data.operators);
                             }
+                            window.updateLiveScanStatus?.(data);
+                        } catch {}
+                    });
+
+                    this._eventSource.addEventListener('scan:progress', (e) => {
+                        try {
+                            const data = JSON.parse(e.data);
+                            window.recordLiveScanEvent?.(data);
                         } catch {}
                     });
 
@@ -6907,13 +6965,202 @@ Correlating findings across agents, identifying patterns, producing actionable i
             }));
         }
 
+        const LiveScanState = {
+            status: null,
+            events: [],
+            seen: new Set()
+        };
+
+        function liveScanEscape(value) {
+            return String(value ?? '').replace(/[&<>"']/g, ch => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            }[ch]));
+        }
+
+        function liveScanTime(ts) {
+            const date = ts ? new Date(ts) : new Date();
+            return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+        }
+
+        function liveScanStatusColor(status) {
+            const s = String(status || '').toLowerCase();
+            if (s === 'completed' || s === 'idle') return '#00ff88';
+            if (s === 'failed' || s === 'burned') return '#ff4444';
+            if (s === 'running' || s === 'tasked' || s === 'executing' || s === 'in_progress') return '#00aaff';
+            if (s === 'pending' || s === 'cooldown') return '#ffaa00';
+            return 'var(--text-secondary)';
+        }
+
+        function liveScanKindLabel(kind) {
+            return ({
+                task_started: 'START',
+                thinking: 'THINK',
+                tool_call: 'TOOL',
+                tool_result: 'RESULT',
+                task_completed: 'DONE',
+                task_failed: 'FAIL'
+            })[kind] || String(kind || 'EVENT').toUpperCase();
+        }
+
+        function liveScanMergeEvents(events) {
+            if (!Array.isArray(events)) return;
+            events.forEach(ev => {
+                const id = ev?.id || `${ev?.timestamp || Date.now()}-${ev?.operatorId || ''}-${ev?.kind || ''}-${ev?.detail || ''}`;
+                if (LiveScanState.seen.has(id)) return;
+                LiveScanState.seen.add(id);
+                LiveScanState.events.push({ ...ev, id });
+            });
+            LiveScanState.events.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+            if (LiveScanState.events.length > 300) {
+                const trimmed = LiveScanState.events.splice(0, LiveScanState.events.length - 300);
+                trimmed.forEach(ev => LiveScanState.seen.delete(ev.id));
+            }
+        }
+
+        window.recordLiveScanEvent = function recordLiveScanEvent(event) {
+            liveScanMergeEvents([event]);
+            renderLiveScanPage();
+        };
+
+        window.updateLiveScanStatus = function updateLiveScanStatus(status) {
+            LiveScanState.status = status || null;
+            liveScanMergeEvents(status?.progress);
+            renderLiveScanPage();
+        };
+
+        window.refreshLiveScanPage = async function refreshLiveScanPage() {
+            const status = await T3MP3ST_API.get('/api/mission/status');
+            window.updateLiveScanStatus(status);
+        };
+
+        window.clearLiveScanFeed = function clearLiveScanFeed() {
+            LiveScanState.events = [];
+            LiveScanState.seen = new Set();
+            renderLiveScanPage();
+        };
+
+        function renderLiveScanPage() {
+            const page = document.getElementById('page-live-scan');
+            if (!page) return;
+
+            const status = LiveScanState.status || {};
+            const active = status.active ?? status.running ?? false;
+            const mission = status.mission || {};
+            const operators = Array.isArray(status.operators?.details) ? status.operators.details : [];
+            const operatorSummary = status.operators?.summary || status.operators || {};
+            const tasks = Array.isArray(status.tasks) ? status.tasks : [];
+            const events = LiveScanState.events.slice().reverse();
+            const currentPhase = mission.currentPhase || status.currentPhase || 'none';
+            const progress = typeof mission.progress === 'number' ? `${Math.round(mission.progress)}%` : '-';
+
+            const summary = document.getElementById('liveScanSummary');
+            if (summary) {
+                const cells = [
+                    ['State', status.paused ? 'Paused' : (active ? 'Running' : 'Stopped'), active ? '#00ff88' : '#ffaa00'],
+                    ['Phase', currentPhase, '#00aaff'],
+                    ['Progress', progress, '#00ff88'],
+                    ['Operators', String(operatorSummary.total ?? operators.length ?? 0), '#ffaa00'],
+                    ['Tasks', String(tasks.length), '#00aaff'],
+                    ['Stall', status.stallReason || '-', status.stallReason ? '#ff4444' : 'var(--text-secondary)']
+                ];
+                summary.innerHTML = cells.map(([label, value, color]) => `
+                    <div style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;padding:12px;min-height:74px;">
+                        <div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">${liveScanEscape(label)}</div>
+                        <div style="font-family:'JetBrains Mono',monospace;font-size:18px;color:${color};overflow-wrap:anywhere;">${liveScanEscape(value)}</div>
+                    </div>
+                `).join('');
+            }
+
+            const opCount = document.getElementById('liveScanOperatorCount');
+            if (opCount) opCount.textContent = `${operatorSummary.busy ?? operators.filter(op => ['tasked', 'executing'].includes(op.status)).length ?? 0} busy`;
+            const opEl = document.getElementById('liveScanOperators');
+            if (opEl) {
+                if (!operators.length) {
+                    opEl.innerHTML = '<div style="padding:18px;color:var(--text-muted);font-size:12px;">No operator details available yet.</div>';
+                } else {
+                    opEl.innerHTML = operators.map(op => {
+                        const statusColor = liveScanStatusColor(op.status);
+                        return `
+                            <div style="padding:12px 14px;border-bottom:1px solid rgba(255,255,255,0.06);display:grid;grid-template-columns:1fr auto;gap:8px;align-items:start;">
+                                <div>
+                                    <div style="font-size:13px;color:var(--text-primary);font-weight:700;">${liveScanEscape(op.callsign || op.id)}</div>
+                                    <div style="font-size:11px;color:var(--text-muted);margin-top:4px;">${liveScanEscape(op.archetype || 'operator')}</div>
+                                    <div style="font-size:10px;color:var(--text-secondary);margin-top:7px;">${Number(op.completedTasks || 0)} done · ${Number(op.failedTasks || 0)} failed · risk ${Number(op.detectionRisk || 0)}</div>
+                                </div>
+                                <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:${statusColor};text-transform:uppercase;">${liveScanEscape(op.status || 'unknown')}</div>
+                            </div>
+                        `;
+                    }).join('');
+                }
+            }
+
+            const taskCount = document.getElementById('liveScanTaskCount');
+            if (taskCount) taskCount.textContent = `${tasks.length} tasks`;
+            const taskEl = document.getElementById('liveScanTasks');
+            if (taskEl) {
+                if (!tasks.length) {
+                    taskEl.innerHTML = '<div style="padding:18px;color:var(--text-muted);font-size:12px;">No mission tasks are queued.</div>';
+                } else {
+                    taskEl.innerHTML = tasks.map(task => {
+                        const color = liveScanStatusColor(task.status);
+                        const output = task.result?.error || task.result?.output || '';
+                        return `
+                            <div style="padding:11px 14px;border-bottom:1px solid rgba(255,255,255,0.06);display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;">
+                                <div style="min-width:0;">
+                                    <div style="font-size:12px;color:var(--text-primary);font-weight:700;overflow-wrap:anywhere;">${liveScanEscape(task.name || task.id)}</div>
+                                    <div style="font-size:10px;color:var(--text-muted);margin-top:4px;">${liveScanEscape(task.phase || '-')} · ${liveScanEscape(task.operatorType || '-')} ${task.assignedTo ? '· ' + liveScanEscape(task.assignedTo) : ''}</div>
+                                    ${output ? `<div style="font-size:10px;color:var(--text-secondary);margin-top:6px;overflow-wrap:anywhere;">${liveScanEscape(output).slice(0, 260)}</div>` : ''}
+                                </div>
+                                <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:${color};text-transform:uppercase;">${liveScanEscape(task.status || 'unknown')}</div>
+                            </div>
+                        `;
+                    }).join('');
+                }
+            }
+
+            const feedCount = document.getElementById('liveScanFeedCount');
+            if (feedCount) feedCount.textContent = `${LiveScanState.events.length} events`;
+            const feed = document.getElementById('liveScanFeed');
+            if (feed) {
+                if (!events.length) {
+                    feed.innerHTML = '<div style="padding:18px;color:var(--text-muted);font-size:12px;">No live reasoning events yet. Start or refresh a scan to populate this stream.</div>';
+                } else {
+                    feed.innerHTML = events.map(ev => {
+                        const color = ev.kind === 'task_failed' || ev.success === false ? '#ff6666'
+                            : ev.kind === 'tool_call' ? '#ffaa00'
+                            : ev.kind === 'tool_result' ? '#00aaff'
+                            : ev.kind === 'thinking' ? '#cfd6e6'
+                            : '#00ff88';
+                        return `
+                            <div style="padding:10px 14px;border-bottom:1px solid rgba(255,255,255,0.055);display:grid;grid-template-columns:76px 74px minmax(110px,180px) minmax(0,1fr);gap:10px;align-items:start;">
+                                <div style="font-size:10px;color:var(--text-muted);">${liveScanTime(ev.timestamp)}</div>
+                                <div style="font-size:10px;color:${color};font-weight:800;">${liveScanEscape(liveScanKindLabel(ev.kind))}</div>
+                                <div style="font-size:10px;color:var(--accent);overflow-wrap:anywhere;">${liveScanEscape(ev.callsign || ev.archetype || ev.operatorId || '-')}</div>
+                                <div style="min-width:0;">
+                                    <div style="font-size:11px;color:var(--text-secondary);margin-bottom:4px;overflow-wrap:anywhere;">${liveScanEscape(ev.taskName || ev.toolName || '-')}</div>
+                                    <div style="font-size:12px;color:var(--text-primary);line-height:1.45;white-space:pre-wrap;overflow-wrap:anywhere;">${liveScanEscape(ev.detail || '')}</div>
+                                </div>
+                            </div>
+                        `;
+                    }).join('');
+                }
+            }
+        }
+
+        setInterval(() => {
+            if (document.getElementById('page-live-scan')?.classList.contains('active')) {
+                window.refreshLiveScanPage?.();
+            }
+        }, 3000);
+
         // Navigation
         function navigateTo(page) {
             document.querySelectorAll('.nav-item').forEach(i => i.classList.toggle('active', i.dataset.page === page));
             document.querySelectorAll('.page').forEach(p => p.classList.toggle('active', p.id === `page-${page}`));
-            const titles = { warroom: 'War Room', operators: 'Operatives', evidence: 'Evidence Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
+            const titles = { warroom: 'War Room', 'live-scan': 'Live Scan', operators: 'Operatives', evidence: 'Evidence Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
             document.getElementById('pageTitle').textContent = titles[page] || 'War Room';
             document.getElementById('sidebar').classList.remove('open');
+            if (page === 'live-scan') setTimeout(() => window.refreshLiveScanPage?.(), 50);
             if (page === 'operators' && typeof window.loadOperativesRoster === 'function') setTimeout(window.loadOperativesRoster, 80);
             if (page === 'evidence' && typeof window.hydrateFindings === 'function') setTimeout(window.hydrateFindings, 60);
             if (page === 'selfimprove' && typeof window.renderSelfImprove === 'function') setTimeout(window.renderSelfImprove, 60);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -137,6 +137,10 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
     if (bootstrapCall) {
       const toolStep = await this.executeTool(bootstrapCall, target, -1);
       steps.push(toolStep);
+      seenCalls.set(
+        `${bootstrapCall.name}:${JSON.stringify(bootstrapCall.arguments || {})}`,
+        String(toolStep.toolResult?.output || toolStep.toolResult?.error || 'no output').replace(/\s+/g, ' ').slice(0, 160)
+      );
 
       if (toolStep.toolResult?.findings) {
         const out = String(toolStep.toolResult.output ?? '').slice(0, 4000);
@@ -158,27 +162,8 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
       });
       messages.push({
         role: 'user',
-        content: 'Use the bootstrap observation above. If it is enough for a concise recon debrief, return the final JSON finding block now. Only call another listed tool if it will materially improve the evidence.',
+        content: 'Use the bootstrap observation above as your first tool observation. Continue through the normal ACTION CONTRACT: request another listed tool only if it will materially improve the evidence; otherwise provide the final recon debrief.',
       });
-
-      if (toolStep.toolResult?.success) {
-        const summary = [
-          'Local-agent recon bootstrap completed with tool-backed evidence.',
-          this.formatToolResult(toolStep.toolResult),
-        ].join('\n\n');
-        const result: AgentResult = {
-          success: true,
-          summary,
-          steps,
-          findings: allFindings,
-          iterations: 0,
-          tokensUsed,
-          durationMs: Date.now() - startTime,
-          hitLimit: false,
-        };
-        this.emit('agent:complete', result);
-        return result;
-      }
     }
 
     for (let i = 0; i < this.options.maxIterations; i++) {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -71,8 +71,8 @@ export interface AgentResult {
 
 export interface AgentEvents {
   'agent:step': AgentStep;
-  'agent:tool_call': { name: string; args: Record<string, unknown> };
-  'agent:tool_result': { name: string; result: ToolResult };
+  'agent:tool_call': { name: string; args: Record<string, unknown>; source?: 'agent' | 'backend_seeded' };
+  'agent:tool_result': { name: string; result: ToolResult; source?: 'agent' | 'backend_seeded' };
   'agent:thinking': { content: string };
   'agent:complete': AgentResult;
   'agent:error': { error: Error; step: number };
@@ -371,7 +371,8 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
     target: Target | undefined,
     iteration: number
   ): Promise<AgentStep> {
-    this.emit('agent:tool_call', { name: toolCall.name, args: toolCall.arguments });
+    const source = iteration < 0 ? 'backend_seeded' : 'agent';
+    this.emit('agent:tool_call', { name: toolCall.name, args: toolCall.arguments, source });
 
     let toolResult: ToolResult;
     try {
@@ -395,7 +396,7 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
       };
     }
 
-    this.emit('agent:tool_result', { name: toolCall.name, result: toolResult });
+    this.emit('agent:tool_result', { name: toolCall.name, result: toolResult, source });
 
     return {
       iteration,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -133,6 +133,54 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
       { role: 'user', content: this.buildTaskPrompt(task, target, toolDefs, sourceContext, sharedContext) },
     ];
 
+    const bootstrapCall = this.getLocalReconBootstrap(task, target, toolDefs);
+    if (bootstrapCall) {
+      const toolStep = await this.executeTool(bootstrapCall, target, -1);
+      steps.push(toolStep);
+
+      if (toolStep.toolResult?.findings) {
+        const out = String(toolStep.toolResult.output ?? '').slice(0, 4000);
+        for (const tf of toolStep.toolResult.findings) {
+          allFindings.push({ ...tf, provenance: 'tool', toolName: bootstrapCall.name, toolOutput: out || tf.details });
+        }
+      }
+
+      messages.push({
+        role: 'assistant',
+        content: 'Running an initial low-noise recon check before planning deeper actions.',
+        toolCalls: [bootstrapCall],
+      });
+      messages.push({
+        role: 'tool',
+        content: this.formatToolResult(toolStep.toolResult),
+        toolCallId: bootstrapCall.id,
+        name: bootstrapCall.name,
+      });
+      messages.push({
+        role: 'user',
+        content: 'Use the bootstrap observation above. If it is enough for a concise recon debrief, return the final JSON finding block now. Only call another listed tool if it will materially improve the evidence.',
+      });
+
+      if (toolStep.toolResult?.success) {
+        const summary = [
+          'Local-agent recon bootstrap completed with tool-backed evidence.',
+          this.formatToolResult(toolStep.toolResult),
+        ].join('\n\n');
+        const result: AgentResult = {
+          success: true,
+          summary,
+          steps,
+          findings: allFindings,
+          iterations: 0,
+          tokensUsed,
+          durationMs: Date.now() - startTime,
+          hitLimit: false,
+        };
+        this.emit('agent:complete', result);
+        return result;
+      }
+    }
+
     for (let i = 0; i < this.options.maxIterations; i++) {
       try {
         // Ask the LLM what to do next
@@ -296,6 +344,38 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
 
     this.emit('agent:complete', result);
     return result;
+  }
+
+  private getLocalReconBootstrap(
+    task: Task,
+    target: Target | undefined,
+    tools: LLMToolDefinition[]
+  ): LLMToolCall | undefined {
+    if (this.llm.getProvider() !== 'local-agent') return undefined;
+    if (!target?.address) return undefined;
+    if (task.phase !== 'reconnaissance' && task.operatorType !== 'recon') return undefined;
+
+    const hasTool = (name: string) => tools.some((tool) => tool.name === name);
+    const taskName = task.name.toLowerCase();
+    const id = `local-agent-bootstrap-${Date.now()}`;
+
+    if (taskName.includes('dns') && hasTool('dns_lookup')) {
+      return { id, name: 'dns_lookup', arguments: { domain: target.address, type: 'A' } };
+    }
+
+    if (taskName.includes('port') && hasTool('port_scan')) {
+      return { id, name: 'port_scan', arguments: { target: target.address, ports: '80,443', timeout: 2000 } };
+    }
+
+    if ((taskName.includes('web') || taskName.includes('fingerprint')) && hasTool('header_analysis')) {
+      return { id, name: 'header_analysis', arguments: { url: `https://${target.address}` } };
+    }
+
+    if ((taskName.includes('content') || taskName.includes('discover')) && hasTool('robots_txt_fetch')) {
+      return { id, name: 'robots_txt_fetch', arguments: { url: `https://${target.address}` } };
+    }
+
+    return undefined;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1018,6 +1018,7 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
 
       // Auto-spawn an operator if none exists for this archetype
       if (!operator) {
+        if (this.llm.getProvider() === 'local-agent') continue;
         const allOps = this.cell.getAllOperators();
         const archetypeCount = allOps.filter(op => op.archetype === task.operatorType).length;
         // Spawn up to 3 operators per archetype for parallelism
@@ -1166,6 +1167,9 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
    * Auto-spawn operators needed for a given kill chain phase
    */
   private autoSpawnForPhase(phase: KillChainPhase): void {
+    if (this.llm.getProvider() === 'local-agent') {
+      return;
+    }
     const phaseOperators: Record<string, OperatorArchetype[]> = {
       [KillChainPhase.RECON]: ['recon'],
       [KillChainPhase.WEAPONIZE]: ['scanner'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -570,15 +570,15 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
       this.recordProgress('thinking', operator, task, content);
     });
 
-    operator.on('agent:tool_call', ({ task, name, args }) => {
-      this.recordProgress('tool_call', operator, task, `${name} ${JSON.stringify(args || {})}`, { toolName: name });
+    operator.on('agent:tool_call', ({ task, name, args, source }) => {
+      this.recordProgress('tool_call', operator, task, `${name} ${JSON.stringify(args || {})}`, { toolName: name, source });
     });
 
-    operator.on('agent:tool_result', ({ task, name, result }) => {
+    operator.on('agent:tool_result', ({ task, name, result, source }) => {
       const detail = result.success
         ? (result.output || 'Tool completed')
         : (result.error || result.output || 'Tool failed');
-      this.recordProgress('tool_result', operator, task, detail, { toolName: name, success: result.success });
+      this.recordProgress('tool_result', operator, task, detail, { toolName: name, success: result.success, source });
     });
 
     operator.on('finding:discovered', ({ finding }) => {
@@ -670,7 +670,7 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     operator: OperatorAgent,
     task: Task | undefined,
     detail: string,
-    extra: Partial<Pick<ScanProgressEvent, 'toolName' | 'success'>> = {}
+    extra: Partial<Pick<ScanProgressEvent, 'toolName' | 'success' | 'source'>> = {}
   ): void {
     const compact = String(detail || '').replace(/\s+/g, ' ').trim().slice(0, 2000);
     const event: ScanProgressEvent = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,8 @@ import type {
   OperatorArchetype,
   CommandEvents,
   Finding,
+  ScanProgressEvent,
+  Task,
 } from './types/index.js';
 
 // Re-export commonly used types
@@ -271,6 +273,7 @@ import {
 
 const DEFAULT_AGENT_MAX_ITERATIONS = 15;
 const LOCAL_AGENT_MAX_ITERATIONS = Number(process.env.T3MP3ST_LOCAL_AGENT_MAX_ITERATIONS || 30);
+const MAX_PROGRESS_EVENTS = 300;
 
 /**
  * TEMPEST Command - Main orchestration controller
@@ -544,6 +547,40 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
    * Setup event forwarding for an operator
    */
   private setupOperatorEvents(operator: OperatorAgent): void {
+    operator.on('task:started', ({ task }) => {
+      this.recordProgress('task_started', operator, task, `Started ${task.name}`);
+    });
+
+    operator.on('task:completed', ({ task, result }) => {
+      const findings = result.findings?.length ? ` Findings: ${result.findings.join(', ')}` : '';
+      this.recordProgress(
+        'task_completed',
+        operator,
+        task,
+        `${result.success === false ? 'Finished unsuccessfully' : 'Completed'} ${task.name}.${findings}`,
+        { success: result.success !== false }
+      );
+    });
+
+    operator.on('task:failed', ({ task, error }) => {
+      this.recordProgress('task_failed', operator, task, error, { success: false });
+    });
+
+    operator.on('agent:thinking', ({ task, content }) => {
+      this.recordProgress('thinking', operator, task, content);
+    });
+
+    operator.on('agent:tool_call', ({ task, name, args }) => {
+      this.recordProgress('tool_call', operator, task, `${name} ${JSON.stringify(args || {})}`, { toolName: name });
+    });
+
+    operator.on('agent:tool_result', ({ task, name, result }) => {
+      const detail = result.success
+        ? (result.output || 'Tool completed')
+        : (result.error || result.output || 'Tool failed');
+      this.recordProgress('tool_result', operator, task, detail, { toolName: name, success: result.success });
+    });
+
     operator.on('finding:discovered', ({ finding }) => {
       this.vault.addFinding(finding);
       this.emit('finding:discovered', { finding, operatorId: operator.id });
@@ -626,6 +663,34 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     operator.on('status:changed', ({ oldStatus: _oldStatus }) => {
       this.hooks.onOperatorStateChange?.({ id: operator.id }, operator.state);
     });
+  }
+
+  private recordProgress(
+    kind: ScanProgressEvent['kind'],
+    operator: OperatorAgent,
+    task: Task | undefined,
+    detail: string,
+    extra: Partial<Pick<ScanProgressEvent, 'toolName' | 'success'>> = {}
+  ): void {
+    const compact = String(detail || '').replace(/\s+/g, ' ').trim().slice(0, 2000);
+    const event: ScanProgressEvent = {
+      id: `progress-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      timestamp: Date.now(),
+      kind,
+      operatorId: operator.id,
+      callsign: operator.callsign,
+      archetype: operator.archetype,
+      taskId: task?.id,
+      taskName: task?.name,
+      detail: compact,
+      ...extra,
+    };
+
+    this.progressEvents.push(event);
+    if (this.progressEvents.length > MAX_PROGRESS_EVENTS) {
+      this.progressEvents.splice(0, this.progressEvents.length - MAX_PROGRESS_EVENTS);
+    }
+    this.emit('scan:progress', event);
   }
 
   /**
@@ -826,6 +891,8 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
    * CLI work; it only fires on truly-hung dispatches. Override via
    * T3MP3ST_TASK_TIMEOUT_MS.
    */
+  private progressEvents: ScanProgressEvent[] = [];
+
   /**
    * Resolve the dispatch timeout from the environment, falling back to the
    * provider-specific default. Guards against a non-numeric / non-positive override.
@@ -1139,6 +1206,7 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     this.on('detection:triggered', (data) => broadcast('detection', data));
     this.on('mission:phase_changed', (data) => broadcast('phase_changed', data));
     this.on('approval:decision', (data) => broadcast('arsenal.approval', data));
+    this.on('scan:progress', (data) => broadcast('scan:progress', data));
     this.on('tick', (count) => {
       // Broadcast status every 5 ticks to avoid flooding
       if (typeof count === 'number' && count % 5 === 0) {
@@ -1232,8 +1300,19 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
     opsec: ReturnType<OpsecController['getStats']>;
     activeMission: string | null;
     stallReason: string | null;
+    progress: ScanProgressEvent[];
+    tasks: Array<{
+      id: string;
+      name: string;
+      phase: string;
+      status: string;
+      operatorType: string;
+      assignedTo?: string;
+      result?: { success: boolean; output?: string; error?: string; findings?: string[] };
+    }>;
   } {
     const activeMission = this.mission.getActiveMission();
+    const taskQueue = this.mission.getTaskQueue();
 
     return {
       name: this.name,
@@ -1246,6 +1325,23 @@ export class TempestCommand extends EventEmitter<CommandEvents> {
       opsec: this.opsec.getStats(),
       activeMission: activeMission?.id || null,
       stallReason: this.stallReason,
+      progress: [...this.progressEvents],
+      tasks: activeMission
+        ? taskQueue.getForMission(activeMission.id).map(task => ({
+            id: task.id,
+            name: task.name,
+            phase: task.phase,
+            status: task.status,
+            operatorType: task.operatorType,
+            assignedTo: task.assignedTo,
+            result: task.result ? {
+              success: task.result.success,
+              output: task.result.output,
+              error: task.result.error,
+              findings: task.result.findings,
+            } : undefined,
+          }))
+        : [],
     };
   }
 

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1052,6 +1052,17 @@ class LocalAgentAdapter implements LLMProviderAdapter {
   validateConfig(): { valid: boolean; error?: string } {
     return this.config.model ? { valid: true } : { valid: false, error: 'local-agent requires the agent id in `model` (codex|claude|hermes)' };
   }
+  private compactContent(content: string, role: LLMMessage['role']): string {
+    let text = content;
+    if (role === 'user') {
+      text = text.replace(/\n### Arsenal \([\s\S]*?\n### Standing Orders/, '\n### Standing Orders');
+    }
+    const cap = role === 'tool' ? 2500 : 6000;
+    if (text.length <= cap) return text;
+    const head = Math.floor(cap * 0.65);
+    const tail = cap - head;
+    return `${text.slice(0, head)}\n... trimmed for local-agent CLI prompt ...\n${text.slice(-tail)}`;
+  }
   private formatPrompt(messages: LLMMessage[], options?: ChatOptions): string {
     const parts = [
       'You are the local-agent planning brain for T3MP3ST, an authorized offensive-security harness.',
@@ -1066,6 +1077,15 @@ class LocalAgentAdapter implements LLMProviderAdapter {
     if (options?.maxTokens) parts.push(`Target max output tokens: ${options.maxTokens}.`);
     for (const m of messages) parts.push(renderCliMessage(m));
     return parts.join('\n');
+  }
+  private parseJsonEnvelope(content: string): unknown | null {
+    const raw = content.trim();
+    const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    const candidates = [fenced?.[1], raw, raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1)].filter(Boolean) as string[];
+    for (const candidate of candidates) {
+      try { return JSON.parse(candidate); } catch { /* try next */ }
+    }
+    return null;
   }
   async chat(messages: LLMMessage[], options?: ChatOptions): Promise<LLMResponse> {
     const agentId = this.config.model || 'codex';

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1052,17 +1052,6 @@ class LocalAgentAdapter implements LLMProviderAdapter {
   validateConfig(): { valid: boolean; error?: string } {
     return this.config.model ? { valid: true } : { valid: false, error: 'local-agent requires the agent id in `model` (codex|claude|hermes)' };
   }
-  private compactContent(content: string, role: LLMMessage['role']): string {
-    let text = content;
-    if (role === 'user') {
-      text = text.replace(/\n### Arsenal \([\s\S]*?\n### Standing Orders/, '\n### Standing Orders');
-    }
-    const cap = role === 'tool' ? 2500 : 6000;
-    if (text.length <= cap) return text;
-    const head = Math.floor(cap * 0.65);
-    const tail = cap - head;
-    return `${text.slice(0, head)}\n... trimmed for local-agent CLI prompt ...\n${text.slice(-tail)}`;
-  }
   private formatPrompt(messages: LLMMessage[], options?: ChatOptions): string {
     const parts = [
       'You are the local-agent planning brain for T3MP3ST, an authorized offensive-security harness.',
@@ -1077,15 +1066,6 @@ class LocalAgentAdapter implements LLMProviderAdapter {
     if (options?.maxTokens) parts.push(`Target max output tokens: ${options.maxTokens}.`);
     for (const m of messages) parts.push(renderCliMessage(m));
     return parts.join('\n');
-  }
-  private parseJsonEnvelope(content: string): unknown | null {
-    const raw = content.trim();
-    const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
-    const candidates = [fenced?.[1], raw, raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1)].filter(Boolean) as string[];
-    for (const candidate of candidates) {
-      try { return JSON.parse(candidate); } catch { /* try next */ }
-    }
-    return null;
   }
   async chat(messages: LLMMessage[], options?: ChatOptions): Promise<LLMResponse> {
     const agentId = this.config.model || 'codex';

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -38,8 +38,8 @@ export interface OperatorEvents {
   'task:failed': { task: Task; error: string };
   'task:decomposed': { parent: Task; subtasks: Task[]; reason: string };
   'agent:thinking': { task: Task; content: string };
-  'agent:tool_call': { task: Task; name: string; args: Record<string, unknown> };
-  'agent:tool_result': { task: Task; name: string; result: ToolResult };
+  'agent:tool_call': { task: Task; name: string; args: Record<string, unknown>; source?: 'agent' | 'backend_seeded' };
+  'agent:tool_result': { task: Task; name: string; result: ToolResult; source?: 'agent' | 'backend_seeded' };
   'finding:discovered': { finding: Finding };
   'finding:gate-blocked': { finding: Finding; reasons: string[] };
   'credential:harvested': { credential: Credential };
@@ -429,11 +429,11 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
       const onThinking = ({ content }: { content: string }): void => {
         this.emit('agent:thinking', { task, content });
       };
-      const onToolCall = ({ name, args }: { name: string; args: Record<string, unknown> }): void => {
-        this.emit('agent:tool_call', { task, name, args });
+      const onToolCall = ({ name, args, source }: { name: string; args: Record<string, unknown>; source?: 'agent' | 'backend_seeded' }): void => {
+        this.emit('agent:tool_call', { task, name, args, source });
       };
-      const onToolResult = ({ name, result }: { name: string; result: ToolResult }): void => {
-        this.emit('agent:tool_result', { task, name, result });
+      const onToolResult = ({ name, result, source }: { name: string; result: ToolResult; source?: 'agent' | 'backend_seeded' }): void => {
+        this.emit('agent:tool_result', { task, name, result, source });
       };
       const canForwardAgentEvents =
         typeof this.agentLoop.on === 'function' &&

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -22,6 +22,7 @@ import {
 import type { LLMBackbone } from '../llm/index.js';
 import type { Arsenal } from '../arsenal/index.js';
 import type { AgentLoop } from '../agent/index.js';
+import type { ToolResult } from '../types/index.js';
 import type { Target } from '../types/index.js';
 import { OPERATOR_SYSTEM_PROMPTS } from '../prompts/index.js';
 import { gateLiveFinding } from '../evidence/gate.js';
@@ -36,6 +37,9 @@ export interface OperatorEvents {
   'task:completed': { task: Task; result: TaskResult };
   'task:failed': { task: Task; error: string };
   'task:decomposed': { parent: Task; subtasks: Task[]; reason: string };
+  'agent:thinking': { task: Task; content: string };
+  'agent:tool_call': { task: Task; name: string; args: Record<string, unknown> };
+  'agent:tool_result': { task: Task; name: string; result: ToolResult };
   'finding:discovered': { finding: Finding };
   'finding:gate-blocked': { finding: Finding; reasons: string[] };
   'credential:harvested': { credential: Credential };
@@ -422,11 +426,38 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
     // Pass the white-box source excerpt (if any) so the model sees the target's
     // real source alongside the task; empty string keeps black-box behavior.
     if (this.agentLoop && this.llm) {
-      // [Phase-2] Register as live on the board and pull the shared situation report so this
-      // operator sees teammates' verified leads/claims — it builds on them instead of running blind.
-      this.board?.heartbeat(this.id, 'hunting', task.name);
-      const sharedContext = this.board?.situationReport(this.id);
-      const result = await this.agentLoop.run(task, this.profile.systemPrompt, target, this.whiteboxSource, sharedContext);
+      const onThinking = ({ content }: { content: string }): void => {
+        this.emit('agent:thinking', { task, content });
+      };
+      const onToolCall = ({ name, args }: { name: string; args: Record<string, unknown> }): void => {
+        this.emit('agent:tool_call', { task, name, args });
+      };
+      const onToolResult = ({ name, result }: { name: string; result: ToolResult }): void => {
+        this.emit('agent:tool_result', { task, name, result });
+      };
+      const canForwardAgentEvents =
+        typeof this.agentLoop.on === 'function' &&
+        typeof this.agentLoop.off === 'function';
+      if (canForwardAgentEvents) {
+        this.agentLoop.on('agent:thinking', onThinking);
+        this.agentLoop.on('agent:tool_call', onToolCall);
+        this.agentLoop.on('agent:tool_result', onToolResult);
+      }
+
+      let result;
+      try {
+        // [Phase-2] Register as live on the board and pull the shared situation report so this
+        // operator sees teammates' verified leads/claims — it builds on them instead of running blind.
+        this.board?.heartbeat(this.id, 'hunting', task.name);
+        const sharedContext = this.board?.situationReport(this.id);
+        result = await this.agentLoop.run(task, this.profile.systemPrompt, target, this.whiteboxSource, sharedContext);
+      } finally {
+        if (canForwardAgentEvents) {
+          this.agentLoop.off('agent:thinking', onThinking);
+          this.agentLoop.off('agent:tool_call', onToolCall);
+          this.agentLoop.off('agent:tool_result', onToolResult);
+        }
+      }
 
       // Convert agent findings to operator findings.
       // PROVENANCE-HONEST: only a tool-backed finding gets tool-output evidence (the raw

--- a/src/server.ts
+++ b/src/server.ts
@@ -6212,7 +6212,7 @@ app.post('/api/mission/resume', (_req: Request, res: Response) => {
 app.get('/api/mission/status', (_req: Request, res: Response) => {
   const cmd = getTempestCommand();
   if (!cmd) {
-    res.json({ active: false });
+    res.json({ active: false, progress: [], tasks: [] });
     return;
   }
 
@@ -6242,6 +6242,8 @@ app.get('/api/mission/status', (_req: Request, res: Response) => {
     targets: status.targets,
     vault: status.vault,
     opsec: status.opsec,
+    tasks: status.tasks,
+    progress: status.progress,
     findings: findings.map(f => ({
       id: f.id,
       title: f.title,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -534,6 +534,20 @@ export interface Appendix {
 // EVENT TYPES
 // =============================================================================
 
+export interface ScanProgressEvent {
+  id: string;
+  timestamp: number;
+  kind: 'task_started' | 'thinking' | 'tool_call' | 'tool_result' | 'task_completed' | 'task_failed';
+  operatorId: string;
+  callsign: string;
+  archetype: OperatorArchetype;
+  taskId?: string;
+  taskName?: string;
+  toolName?: string;
+  detail: string;
+  success?: boolean;
+}
+
 export interface CommandEvents {
   'command:started': void;
   'command:stopped': void;
@@ -547,6 +561,7 @@ export interface CommandEvents {
   'target:owned': { target: Target; operatorId: string };
   'detection:triggered': DetectionEvent;
   'mission:phase_changed': { missionId: string; phase: KillChainPhase };
+  'scan:progress': ScanProgressEvent;
   'abort:recommended': string;
   /** A capability-approval gate decision (allowed/denied) on an intrusive/dangerous tool — bridged to
    *  the dashboard's live approval/audit feed. Structural match for arsenal/approval.ts ApprovalRecord. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -544,6 +544,7 @@ export interface ScanProgressEvent {
   taskId?: string;
   taskName?: string;
   toolName?: string;
+  source?: 'agent' | 'backend_seeded';
   detail: string;
   success?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add a Live Scan page showing mission tasks, operator status, and reasoning/tool progress events
- Stream scan progress over SSE and expose task/progress snapshots from mission status
- Feed local-agent recon bootstrap tool output into the existing ACTION CONTRACT ReAct loop as the first observation
- Label backend-seeded bootstrap tool progress explicitly in the live feed

## Validation
- HOME=/Users/threlfall/Documents/t3mp3st/.home npm run build
- HOME=/Users/threlfall/Documents/t3mp3st/.home npm test
