### PR TITLE
fix(local-agents): support current Codex exec CLI

### DIFF
--- a/src/agent/local-agents.ts
+++ b/src/agent/local-agents.ts
@@ -126,7 +126,17 @@ const SPECS: AgentSpec[] = [
     versionArgs: ['--version'],
     parseVersion: (o) => (o.match(/[\d]+\.[\d]+(\.[\d]+)?/) || ['?'])[0],
     authArtifacts: ['~/.codex/auth.json', '~/.config/codex/auth.json'],
-    oneShot: (p, m) => ['exec', ...(m ? ['-m', m] : []), p],
+    oneShot: (p, m) => [
+      'exec',
+      '--ephemeral',
+      '--skip-git-repo-check',
+      '--sandbox',
+      'read-only',
+      '--color',
+      'never',
+      ...(m ? ['-m', m] : []),
+      p,
+    ],
   },
   {
     id: 'hermes',
@@ -322,7 +332,7 @@ export function localAgentChat(id: string, prompt: string, opts: { model?: strin
   } else if (id === 'codex') {
     workDir = mkdtempSync(join(tmpdir(), 't3mp3st-codexllm-'));
     outFile = join(workDir, 'reply.txt');
-    args = ['exec', '--skip-git-repo-check', '--color', 'never', '--sandbox', 'read-only', '--output-last-message', outFile, ...(model ? ['-m', model] : [])];
+    args = ['exec', '--ephemeral', '--skip-git-repo-check', '--color', 'never', '--sandbox', 'read-only', '--output-last-message', outFile, ...(model ? ['-m', model] : [])];
   } else { // hermes — takes the prompt as an arg
     args = ['-z', prompt, ...(hermesYoloEnabled() ? ['--yolo'] : []), ...(model ? ['-m', model] : [])];
     viaStdin = false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -6654,8 +6654,6 @@ function bringUpMissionFromPlan(
 async function runCodexExecReadinessProbe(command: string): Promise<{ stdout: string; stderr: string }> {
   const marker = 'T3MP3ST_CODEX_READY';
   const args = [
-    '--ask-for-approval',
-    'never',
     'exec',
     '-c',
     'model_reasoning_effort="low"',
@@ -6681,7 +6679,7 @@ async function runCodexExecReadinessProbe(command: string): Promise<{ stdout: st
     const timer = setTimeout(() => {
       child.kill('SIGTERM');
       reject(new Error('Codex exec readiness probe timed out'));
-    }, 30000);
+    }, 60000);
 
     // Bounded accumulation so a runaway/verbose child can't grow these strings without limit
     // before the 30s timer fires (matches the local-agent caps). A normal probe emits a tiny
@@ -6733,7 +6731,7 @@ app.get('/api/codex/status', async (_req: Request, res: Response): Promise<void>
       tokenHandling: 'no token is accepted by or returned from T3MP3ST',
       command,
       version: stdout.trim(),
-      executionMode: 'codex exec --ephemeral --sandbox read-only --ask-for-approval never',
+      executionMode: 'codex exec --ephemeral --sandbox read-only',
       execProbe: 'POST /api/codex/probe',   // exec self-test moved off GET (B-04)
     });
   } catch (error: any) {
@@ -6753,7 +6751,7 @@ app.post('/api/codex/probe', async (_req: Request, res: Response): Promise<void>
       provider: 'codex',
       command,
       version: stdout.trim(),
-      executionMode: 'codex exec --ephemeral --sandbox read-only --ask-for-approval never',
+      executionMode: 'codex exec --ephemeral --sandbox read-only',
     };
     try {
       const probe = await runCodexExecReadinessProbe(command);
@@ -7472,7 +7470,7 @@ type ConnectedLocalAgent = {
 };
 const connectedLocalAgents = new Map<string, ConnectedLocalAgent>();
 const LOCAL_AGENT_HEALTH_TTL_MS = 30_000;
-const LOCAL_AGENT_HEALTH_TIMEOUT_MS = 15_000;
+const LOCAL_AGENT_HEALTH_TIMEOUT_MS = 45_000;
 
 async function refreshConnectedLocalAgentHealth(force = false): Promise<void> {
   const now = Date.now();


### PR DESCRIPTION
## Summary

Fixes the local Codex agent bridge for the current Codex CLI.

Changes:
- removes the obsolete `--ask-for-approval never` flag from the server Codex readiness probe
- runs Codex as `codex exec ...` with supported noninteractive flags
- uses ephemeral read-only Codex exec for local-agent one-shot calls
- raises connected-agent health-check timeout from 15s to 45s because Codex round trips commonly take ~40s on this machine
- updates `/api/codex/status` execution-mode text to match the actual command

## Why

The UI could show Codex as installed/authed, but the live probe and local-agent connection could fail or appear as “connected but not live.” On this host, the old command failed argument parsing for `--ask-for-approval`, and real Codex pings took roughly 40 seconds, longer than the 15s health timeout and old 30s readiness probe.

## Validation

On the patched production server at `http://127.0.0.1:3334`:

- `npm run typecheck`
- `npm test` — 34 files / 393 tests passed
- `npm run build`
- direct Codex readiness command returned `T3MP3ST_CODEX_READY`
- `POST /api/codex/probe` returned `execReady: true`, `selfTest: passed`
- `POST /api/agents/local/connect` with `{ "id": "codex", "ping": true, "replace": true }` returned active Codex with `PONG` in ~40s
- `POST /api/agents/local/dispatch` returned `LOCAL_AGENT_DISPATCH_OK` in ~44s
