### PR TITLE
fix(server): avoid caller cwd dotenv loading

### DIFF
--- a/src/__tests__/api-key-env-static.test.ts
+++ b/src/__tests__/api-key-env-static.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const configSource = readFileSync(join(process.cwd(), 'src/config/index.ts'), 'utf8');
+const serverSource = readFileSync(join(process.cwd(), 'src/server.ts'), 'utf8');
 const setupScript = readFileSync(join(process.cwd(), 'scripts/setup-api.sh'), 'utf8');
 
 function sourceBlock(startMarker: string, endMarker: string): string {
@@ -31,6 +32,11 @@ describe('API key environment handling hardening', () => {
 
     expect(block).not.toContain("join(process.cwd(), '.env')");
     expect(block).toContain("join(homedir(), '.t3mp3st', '.env')");
+  });
+
+  it('the API server does not re-enable caller-cwd dotenv loading', () => {
+    expect(serverSource).not.toMatch(/from ['"]dotenv['"]/);
+    expect(serverSource).not.toMatch(/\bdotenv\.config\s*\(/);
   });
 
   it('setup-api.sh writes the same T3MP3ST-owned env file that ConfigManager reads', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,9 +32,6 @@ import type { OperatorArchetype } from './types/index.js';
 import { listOperatorPrompts, setOperatorOverride, resetOperatorOverride, type OperatorOverride } from './operators/index.js';
 import { ingestRepoToSourceContext, runWhiteboxAnalysis, resolveContainedRepoPath, RepoPathError } from './recon/whitebox.js';
 import { redactCredential } from './evidence/index.js';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 const execFileAsync = promisify(execFile);
 


### PR DESCRIPTION
## Summary
- remove the API server top-level dotenv load
- keep environment loading confined to the T3MP3ST-owned config paths
- add a regression assertion to the existing environment-hardening test

## Root cause
The server called dotenv.config() at module load. When launched from an audited target repository, dotenv implicitly loaded that repository .env into the T3MP3ST process, exposing unrelated target credentials to server behavior.

This is a current-main replacement for #23 by @mane. The implementation and regression intent come from that contribution; the maintainer replacement only resolves the stale test conflict.

## Validation
- npm ci
- npm run typecheck
- npx vitest run src/__tests__/api-key-env-static.test.ts (7 tests)
- npm test (34 files / 394 tests)
- npm run build
- npm audit: 0 vulnerabilities

Supersedes #23.