### PR TITLE
test(ui): semantic defect gate for inline scripts (#111 hardening)

### DIFF
--- a/src/__tests__/ui-inline-scripts-parse.test.ts
+++ b/src/__tests__/ui-inline-scripts-parse.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
+import { Linter } from 'eslint';
 
 const html = readFileSync(new URL('../../docs/index.html', import.meta.url), 'utf8');
 
@@ -44,12 +45,59 @@ describe('docs/index.html inline scripts (issue #111 regression)', () => {
     const failures: string[] = [];
     blocks.forEach((src, i) => {
       try {
-        // eslint-disable-next-line no-new
         new vm.Script(src, { filename: `docs/index.html#inline-${i}` });
       } catch (e) {
         failures.push(`inline #${i}: ${(e as Error).message}`);
       }
     });
     expect(failures, failures.join('\n')).toEqual([]);
+  });
+});
+
+/**
+ * Second layer — semantic defect gate (#111 hardening).
+ *
+ * The vm.Script check above catches outright *parse* failures. This catches the
+ * shapes a conflict-concatenating auto-merge leaves behind that still PARSE but are
+ * always bugs — duplicate declarations, code after a `return`, duplicate object
+ * keys — using ESLint's high-precision "possible problem" rules run programmatically.
+ * No new dependency (`eslint` is already a devDependency) and no eslint.config / CI
+ * change: this rides the existing `npm test`. #111 shipped 8 such scars past a CI
+ * that only ever looked at `src/`; this closes that blind spot for the UI too.
+ *
+ * The rule set is deliberately a tight, always-a-bug set, and each `<script>` is
+ * linted in isolation, so it is false-positive-free on the real file. Notably
+ * EXCLUDED, by design:
+ *   - `no-undef` / `no-unused-vars` — the SPA relies on hundreds of cross-<script>
+ *     and browser globals a per-block lint can't see; enabling them would flood.
+ *   - `no-func-assign` — the app legitimately monkey-patches `navigateTo` (wraps it
+ *     to add CTF-range init), a pattern that rule flags.
+ */
+const SCAR_RULES: Linter.RulesRecord = {
+  'no-redeclare': 'error',
+  'no-unreachable': 'error',
+  'no-dupe-keys': 'error',
+  'no-dupe-args': 'error',
+  'no-dupe-else-if': 'error',
+  'no-duplicate-case': 'error',
+  'no-const-assign': 'error',
+  'no-import-assign': 'error',
+  'no-class-assign': 'error',
+};
+
+describe('docs/index.html inline scripts — semantic defect gate (#111 hardening)', () => {
+  it('no duplicate declarations, unreachable code, or duplicate keys in any inline <script>', () => {
+    const linter = new Linter();
+    const config: Linter.Config = {
+      languageOptions: { ecmaVersion: 'latest', sourceType: 'script' },
+      rules: SCAR_RULES,
+    };
+    const findings: string[] = [];
+    inlineScripts(html).forEach((src, i) => {
+      for (const m of linter.verify(src, config)) {
+        findings.push(`inline #${i} L${m.line}:${m.column} [${m.ruleId ?? 'parse'}] ${m.message}`);
+      }
+    });
+    expect(findings, findings.join('\n')).toEqual([]);
   });
 });


### PR DESCRIPTION
## ✅ Now standalone — #112 has merged

Its dependency (**#112**, the fix for **#111**) merged on 2026-07-24, so I've **rebased this onto current `main`**. The diff is now just the one new commit — a single test file, **+49/−1**.

**Chain:** #111 (issue) → #112 (fix, merged) → **this PR** (the CI gate that stops #111 from recurring).

---

## What & why

#111 shipped **8 conflict-concatenation scars** into the 27,000-line SPA — and sailed straight through CI, because `lint`/`test` only ever look at `src/`. The product's primary surface has **no static gate at all**. #112's fix added a `vm.Script` *parse* test (catches outright syntax breakage). This PR adds the **semantic** layer parsing can't see — the shapes a bad auto-merge leaves behind that still parse but are always bugs.

## The gate

A new check in the existing test file runs **ESLint's high-precision "possible problem" rules** over each inline `<script>`:

`no-redeclare`, `no-unreachable`, `no-dupe-keys`, `no-dupe-args`, `no-dupe-else-if`, `no-duplicate-case`, `no-const-assign`, `no-import-assign`, `no-class-assign`.

Deliberately **minimal, additive, dependency-free:**
- **No new dependency** — `eslint` is already a devDependency; used via its `Linter` API.
- **No `eslint.config.js` or `ci.yml` change** — rides the existing `npm test`.
- **No flakiness** — pure static analysis, no browser/server. (A Playwright boot-smoke was considered and deliberately deferred: on a backendless CI its coverage largely overlaps this, while adding a browser dependency and timing flakiness.)

**Precision over recall** — each script is linted in isolation and the rule set is only "always-a-bug" checks, so it's false-positive-free on the real file. Two rules are excluded, reasons documented in-code:
- `no-undef` / `no-unused-vars` — the SPA relies on hundreds of cross-`<script>` and browser globals a per-block lint can't see (would flood).
- `no-func-assign` — the app legitimately monkey-patches `navigateTo` (wraps it to add CTF-range init).

## Validation

- **0 findings** on `main` (no false positives).
- **RED-proven**: the gate rejects the pre-fix tree (catches the duplicate `response`).
- Confirmed it catches each scar shape (dup-decl, unreachable-after-return, dup-key).
- `tsc --noEmit` clean; `npm run lint` adds 0 errors/warnings; **full suite 647 green**.

Relates to #111 / #112.
