### PR TITLE
fix(tools): run as non-root user and move binaries to /usr/local/bin

### DIFF
--- a/ctf/docker-compose.yml
+++ b/ctf/docker-compose.yml
@@ -46,6 +46,11 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{bl1nd_sql1_t1m3_b4s3d}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
     labels:
@@ -66,6 +71,11 @@ services:
     depends_on:
       - webhook-receiver
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
     labels:
@@ -85,6 +95,11 @@ services:
     depends_on:
       - metadata-mock
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
       - ctf-internal
@@ -107,6 +122,11 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{b4s1c_buff3r_0v3rfl0w}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "kill -0 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
     labels:
@@ -124,6 +144,11 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{f0rm4t_str1ng_g0t_wr1t3}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "kill -0 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
     labels:
@@ -145,6 +170,11 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{w34k_rs4_pr1m3_f4ct0r}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
     labels:
@@ -168,6 +198,11 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{v0l4t1l1ty_m3m0ry_dump}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
     labels:
@@ -215,6 +250,11 @@ services:
       "
     ports:
       - "9999:9999"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9999/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - ctf-network
 
@@ -255,6 +295,11 @@ services:
       "
     environment:
       - CTF_FLAG=T3MP3ST{ssrf_t0_cl0ud_m3t4d4t4}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:80/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       ctf-internal:
         ipv4_address: 169.254.169.254

--- a/ctf/docker-compose.yml
+++ b/ctf/docker-compose.yml
@@ -46,11 +46,6 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{bl1nd_sql1_t1m3_b4s3d}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
     labels:
@@ -71,11 +66,6 @@ services:
     depends_on:
       - webhook-receiver
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
     labels:
@@ -95,11 +85,6 @@ services:
     depends_on:
       - metadata-mock
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
       - ctf-internal
@@ -122,11 +107,6 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{b4s1c_buff3r_0v3rfl0w}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD-SHELL", "kill -0 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
     labels:
@@ -144,11 +124,6 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{f0rm4t_str1ng_g0t_wr1t3}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD-SHELL", "kill -0 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
     labels:
@@ -170,11 +145,6 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{w34k_rs4_pr1m3_f4ct0r}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
     labels:
@@ -198,11 +168,6 @@ services:
     environment:
       - CTF_FLAG=T3MP3ST{v0l4t1l1ty_m3m0ry_dump}
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
     labels:
@@ -250,11 +215,6 @@ services:
       "
     ports:
       - "9999:9999"
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9999/')"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       - ctf-network
 
@@ -295,11 +255,6 @@ services:
       "
     environment:
       - CTF_FLAG=T3MP3ST{ssrf_t0_cl0ud_m3t4d4t4}
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:80/')"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
     networks:
       ctf-internal:
         ipv4_address: 169.254.169.254

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:cybench-ci": "node scripts/test-cybench-ci.mjs",
     "tools:check": "bash scripts/check-tools-image.sh",
     "tools:build": "bash tools/build.sh",
+    "test:tools-dockerfile": "node scripts/test-tools-dockerfile.mjs",
     "install:tools": "bash scripts/install-tools.sh",
     "mcp": "tsx src/mcp-server.ts",
     "mcp:prod": "node dist/mcp-server.js",

--- a/scripts/check-tools-image.sh
+++ b/scripts/check-tools-image.sh
@@ -17,7 +17,7 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 echo "Checking tools image: $IMAGE"
-docker run --rm --platform linux/amd64 "$IMAGE" bash -lc '
+docker run --rm --platform linux/amd64 "$IMAGE" bash -c '
   set -e
   fail=0
   for c in radare2 gdb objdump upx; do

--- a/scripts/test-tools-dockerfile.mjs
+++ b/scripts/test-tools-dockerfile.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Regression guard for the tools image's non-root runtime contract.
+ *
+ * Python packages install console scripts in /usr/local/bin (including httpx).
+ * Go tools must therefore be built in a staging directory before installation,
+ * otherwise `go install` refuses to overwrite the existing Python script.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const dockerfile = fs.readFileSync(path.join(here, '..', 'tools', 'Dockerfile'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function check(label, condition) {
+  if (condition) {
+    passed += 1;
+    console.log(`  ok   ${label}`);
+  } else {
+    failed += 1;
+    console.error(`  FAIL ${label}`);
+  }
+}
+
+check(
+  'Go binaries are not built directly into /usr/local/bin',
+  !/export\s+GOBIN=\/usr\/local\/bin/.test(dockerfile),
+);
+check(
+  'Go binaries use a staging directory',
+  /export\s+GOBIN=\/tmp\/projectdiscovery-bin/.test(dockerfile),
+);
+check(
+  'staged Go binaries are installed into /usr/local/bin',
+  /install\s+-m\s+0755\s+"\$GOBIN"\/\*\s+\/usr\/local\/bin\//.test(dockerfile),
+);
+check(
+  'Go staging directory is removed',
+  /rm\s+-rf\s+"\$GOBIN"/.test(dockerfile),
+);
+check(
+  'operator user reuses the existing Kali operator group',
+  /useradd\s+--gid\s+operator\s+--create-home\s+--shell\s+\/bin\/bash\s+operator/.test(dockerfile),
+);
+check('image runtime user is operator', /^USER operator$/m.test(dockerfile));
+check('image runtime workdir is /work', /^WORKDIR \/work$/m.test(dockerfile));
+
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'}: ${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/test-tools-dockerfile.mjs
+++ b/scripts/test-tools-dockerfile.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const dockerfile = fs.readFileSync(path.join(here, '..', 'tools', 'Dockerfile'), 'utf8');
+const smokeScript = fs.readFileSync(path.join(here, 'check-tools-image.sh'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -48,6 +49,11 @@ check(
 );
 check('image runtime user is operator', /^USER operator$/m.test(dockerfile));
 check('image runtime workdir is /work', /^WORKDIR \/work$/m.test(dockerfile));
+check(
+  'tools smoke avoids a login shell whose logout hook can mask success',
+  /docker run .* "\$IMAGE" bash -c '/.test(smokeScript) &&
+    !/docker run .* "\$IMAGE" bash -lc '/.test(smokeScript),
+);
 
 console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'}: ${passed} passed, ${failed} failed`);
 process.exit(failed === 0 ? 0 : 1);

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -14,8 +14,7 @@
 FROM kalilinux/kali-rolling
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PIP_BREAK_SYSTEM_PACKAGES=1 \
-    PATH="/root/go/bin:/root/.foundry/bin:${PATH}"
+    PIP_BREAK_SYSTEM_PACKAGES=1
 
 # ── apt: reverse/crypto/pwn + web/recon + osint, plus build deps for the pip layer ──
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -50,7 +49,8 @@ RUN pip3 install --no-cache-dir pipx \
  && (pipx install mythril          || echo "WARN: mythril pipx install failed")
 
 # ── go: the "+" — ProjectDiscovery suite + dalfox (not in stock Kali apt) ──
-RUN go install github.com/projectdiscovery/httpx/cmd/httpx@latest        && \
+RUN export GOBIN=/usr/local/bin && \
+    go install github.com/projectdiscovery/httpx/cmd/httpx@latest        && \
     go install github.com/projectdiscovery/katana/cmd/katana@latest      && \
     go install github.com/projectdiscovery/naabu/v2/cmd/naabu@latest     && \
     go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
@@ -62,7 +62,8 @@ RUN go install github.com/projectdiscovery/httpx/cmd/httpx@latest        && \
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && \
     npm install -g solhint && \
     rm -rf /var/lib/apt/lists/* /root/.npm
-RUN curl -L https://foundry.paradigm.xyz | bash && /root/.foundry/bin/foundryup || \
+RUN curl -L https://foundry.paradigm.xyz | bash && /root/.foundry/bin/foundryup && \
+    cp /root/.foundry/bin/forge /root/.foundry/bin/cast /root/.foundry/bin/anvil /usr/local/bin/ 2>/dev/null || \
     echo "foundry install skipped (offline build) — re-run foundryup later"
 
 # nuclei templates (best-effort; the scan still runs without a fresh pull)
@@ -79,5 +80,8 @@ RUN curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download
  && /opt/conda/bin/conda clean -afy \
  || echo "WARN: sage (conda-forge) install failed/skipped — crypto falls back to z3/sympy/fpylll"
 
+RUN useradd --create-home --shell /bin/bash operator && mkdir -p /work && chown operator:operator /work
+
+USER operator
 WORKDIR /work
 CMD ["bash"]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -49,14 +49,18 @@ RUN pip3 install --no-cache-dir pipx \
  && (pipx install mythril          || echo "WARN: mythril pipx install failed")
 
 # ── go: the "+" — ProjectDiscovery suite + dalfox (not in stock Kali apt) ──
-RUN export GOBIN=/usr/local/bin && \
+# Stage first: the Python dependency layer already creates /usr/local/bin/httpx,
+# and `go install` refuses to overwrite a non-Go executable at GOBIN. `install`
+# deliberately replaces that console script with ProjectDiscovery httpx.
+RUN export GOBIN=/tmp/projectdiscovery-bin && \
     go install github.com/projectdiscovery/httpx/cmd/httpx@latest        && \
     go install github.com/projectdiscovery/katana/cmd/katana@latest      && \
     go install github.com/projectdiscovery/naabu/v2/cmd/naabu@latest     && \
     go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
     go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest   && \
     go install github.com/hahwul/dalfox/v2@latest                        && \
-    rm -rf /root/go/pkg /root/.cache/go-build
+    install -m 0755 "$GOBIN"/* /usr/local/bin/                           && \
+    rm -rf "$GOBIN" /root/go/pkg /root/.cache/go-build
 
 # ── npm + foundry: smart-contract "+" (solhint, forge/cast) ──
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && \
@@ -80,7 +84,10 @@ RUN curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download
  && /opt/conda/bin/conda clean -afy \
  || echo "WARN: sage (conda-forge) install failed/skipped — crypto falls back to z3/sympy/fpylll"
 
-RUN useradd --create-home --shell /bin/bash operator && mkdir -p /work && chown operator:operator /work
+# Kali already defines the operator group; attach the runtime user to it.
+RUN useradd --gid operator --create-home --shell /bin/bash operator \
+ && mkdir -p /work \
+ && chown operator:operator /work
 
 USER operator
 WORKDIR /work


### PR DESCRIPTION
## Summary
- Add non-root `operator` user so the Kali tools container no longer runs as root by default
- Move Go and Foundry binaries to `/usr/local/bin` (accessible to non-root) instead of `/root/go/bin` and `/root/.foundry/bin`
- Remove `/root` paths from `PATH` env

## Test plan
- [ ] `npm run tools:build` succeeds
- [ ] `npm run tools:check` passes (radare2/gdb/objdump/upx + python stack + pip-audit)
- [ ] Container runs as `operator` user: `docker run --rm cybench-tools:latest whoami` → `operator`
- [ ] Go tools accessible: `docker run --rm cybench-tools:latest nuclei -version`