### PR TITLE
fix(ctf): make sqli-basic lab buildable and healthy

### DIFF
--- a/ctf/docker-compose.yml
+++ b/ctf/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - CTF_FLAG=T3MP3ST{sql1_l0g1n_byp4ss_ez}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      test: ["CMD", "python", "-c", "import urllib.request;urllib.request.urlopen('http://localhost:80/health')"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/ctf/docker/web/sqli-basic/Dockerfile
+++ b/ctf/docker/web/sqli-basic/Dockerfile
@@ -9,9 +9,8 @@ WORKDIR /app
 # Install dependencies
 RUN pip install flask flask-cors
 
-# Create vulnerable application
+# Create vulnerable application (self-contained: templates are inline via render_template_string)
 COPY app.py /app/
-COPY templates/ /app/templates/
 
 # Set environment variables
 ENV FLASK_APP=app.py


### PR DESCRIPTION
## What changed

Two small fixes to the `sqli-basic` CTF challenge, which currently cannot be built or reported healthy:

1. **`ctf/docker/web/sqli-basic/Dockerfile`** — drop stale `COPY templates/ /app/templates/`. The directory does not exist in the repo, so `docker compose up -d --build sqli-basic` fails at build time (`COPY failed: file not found in build context`). The app is self-contained: it renders via `render_template_string(LOGIN_PAGE/ADMIN_PAGE)` and never reads `templates/`.
2. **`ctf/docker-compose.yml`** — replace the `curl`-based healthcheck with a stdlib Python probe (`python -c "import urllib.request;urllib.request.urlopen('http://localhost:80/health')"`). `python:3.11-slim` ships no `curl`, so the container stayed `unhealthy` (`exec: "curl": executable file not found`) even though `/health` answered 200.

After the fix: image builds, container starts and reports **healthy**, `GET /` serves the login page, `GET /health` returns OK.

## Scope audit

`git diff --name-status main...HEAD`:

```
M\tctf/docker-compose.yml
M\tctf/docker/web/sqli-basic/Dockerfile
```

Branch created fresh from current `main` (`b192577`); single cherry-picked commit, no stale-base churn, no protected/evidence paths touched.

## Contribution Receipt

- Change: CTF lab build + healthcheck repair for `sqli-basic`
- Scope class: `ctf_range`
- Target authority: local Docker lab owned by the operator; no external systems
- Network use: `loopback` (container published on 127.0.0.1:8080 during verification)
- Run mode labels: n/a (no mission/run-mode changes)
- Model/harness labels: n/a (no LLM/provider changes)
- Commands run (on this exact branch, macOS 25.5.0 arm64, Node v22.22.2):
  - `npm run typecheck` -> pass (exit 0)
  - `npm test` -> 643/644 pass (exit 1): single failure in `src/__tests__/local-agent-path-resolution.test.ts` ("reports Claude Code installed + versioned when claude lives in ~/.local/bin and PATH omits it"). Reproduced **identically on clean `main` (`b192577`)** in a separate worktree — pre-existing, environment-dependent (dev machine with local agent CLIs installed), unrelated to this docker-only change.
  - `npm run doctor` -> pass (exit 0; warns only about optional missing nuclei/semgrep/promptfoo)
  - `npm run verify-claims` -> skipped (no benchmark or headline-claim changes)
  - `docker compose -f ctf/docker-compose.yml up -d --build sqli-basic` -> builds; container `healthy`; `/health` 200
- Artifacts: none durable (lab stopped with `docker compose down` after verification)
- Redaction: nothing to redact (no credentials, tokens, or PII in the change)
- Claims changed: none
- Abstentions/refusals: `verify-claims` skipped per guide condition; no other challenges touched — `sqli-blind`, `xss-stored`, `ssrf-metadata`, `format-string`, `rsa-weak`, `memory-dump` have no build context in the repo at all (empty/missing dirs); fixing them is out of scope for this PR
- Residual risk: the pre-existing `local-agent-path-resolution` test failure on machines with CLIs in `~/.local/bin` may warrant a separate look; healthcheck probe assumes `python` on PATH inside the image (true for `python:3.11-slim`)