### PR TITLE
fix(warroom): repair broken LLM-call sites so docs/index.html parses

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11290,29 +11290,6 @@ Bypass all protections:
         // Shared safe LLM call — resolves the backend, then routes the call. Keyless backends
         // (connected agent / server LLM) run single-shot through the server; key backends
         // (OpenRouter / Venice) call the provider directly and keep the model-fallback chain.
-        async function safeLLMCall(prompt, options = {}) {
-            const backend = resolveLLMBackend();
-            if (backend.kind === 'none') throw new Error(LLM_BACKEND_HINT);
-
-            if (backend.kind === 'agent' || backend.kind === 'server') {
-                if (typeof trackApiCall === 'function') trackApiCall();
-                const label = backend.kind === 'agent' ? ('agent:' + backend.agentId) : 'server-llm';
-                addIntel('API', `→ ${label}`, 'info');
-                const content = await _backendCall(backend, prompt, options);
-                if (!content || content.trim().length < 10) throw new Error(`${label} returned empty response`);
-                currentModelInUse = label;
-                return content;
-            }
-
-            const primaryModel = options.model || state.settings?.selectedModel || 'anthropic/claude-opus-4.6';
-            const fallbackModel = state.settings?.fallbackModel || 'nousresearch/hermes-3-llama-3.1-405b';
-            let models;
-            if (backend.kind === 'venice') {
-                models = [veniceModel(options.model || state.settings?.selectedModel)];
-            } else {
-                models = options._noFallback ? [primaryModel]
-                    : (primaryModel === fallbackModel ? [primaryModel] : [primaryModel, fallbackModel]);
-            }
         // Same-origin proxy the browser "AI" features POST to when local mode is on.
         // The server (npm run server) serves this page, so /api/llm/chat is same-origin
         // (no CORS) and reuses LLMBackbone -> LocalAdapter to reach llama.cpp/Ollama.
@@ -11507,6 +11484,21 @@ Bypass all protections:
 
         // Shared safe LLM call — handles response.ok, JSON parsing, timeouts, model fallback
         async function safeLLMCall(prompt, options = {}) {
+            const backend = resolveLLMBackend();
+            if (backend.kind === 'none') throw new Error(LLM_BACKEND_HINT);
+
+            // Keyless routing: a connected local agent (Claude Code/Codex/Hermes) or the
+            // server's own configured LLM answers through the same-origin server, not the browser.
+            if (backend.kind === 'agent' || backend.kind === 'server') {
+                if (typeof trackApiCall === 'function') trackApiCall();
+                const label = backend.kind === 'agent' ? ('agent:' + backend.agentId) : 'server-llm';
+                addIntel('API', `→ ${label}`, 'info');
+                const content = await _backendCall(backend, prompt, options);
+                if (!content || content.trim().length < 10) throw new Error(`${label} returned empty response`);
+                currentModelInUse = label;
+                return content;
+            }
+
             const localMode = !!state.settings?.useLocal;
             const apiKey = localMode ? 'local' : getApiKey();
             if (!localMode && !apiKey) throw new Error('No API key configured');
@@ -11589,19 +11581,6 @@ Bypass all protections:
                 : 'https://openrouter.ai/api/v1/chat/completions';
             const headers = { 'Authorization': `Bearer ${backend.key}`, 'Content-Type': 'application/json' };
             if (backend.kind === 'openrouter') { headers['HTTP-Referer'] = window.location.href; headers['X-Title'] = options.title || 'T3MP3ST'; }
-            const response = await fetch(endpoint, {
-                method: 'POST',
-                headers,
-                body: JSON.stringify({
-                    model,
-                    messages: Array.isArray(prompt)
-                        ? prompt
-                        : [{ role: 'user', content: prompt }],
-                    max_tokens: options.maxTokens || 4096,
-                    temperature: options.temperature ?? 0.3
-                }),
-                signal: AbortSignal.timeout(options.timeout || 120000)
-            });
 
             // LOCAL MODE: route through the same-origin server proxy (reuses
             // LLMBackbone -> LocalAdapter; avoids browser CORS against llama.cpp/localhost).
@@ -11655,14 +11634,9 @@ Bypass all protections:
             const cloudTimer = setTimeout(() => cloudController.abort(), cloudTimeoutMs);
             let response;
             try {
-                response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+                response = await fetch(endpoint, {
                     method: 'POST',
-                    headers: {
-                        'Authorization': `Bearer ${apiKey}`,
-                        'Content-Type': 'application/json',
-                        'HTTP-Referer': window.location.href,
-                        'X-Title': options.title || 'T3MP3ST'
-                    },
+                    headers,
                     body: JSON.stringify({
                         model,
                         messages: Array.isArray(prompt)
@@ -11707,11 +11681,6 @@ Bypass all protections:
             if (mode === 'live') {
                 if (resolveLLMBackend().kind === 'none') {
                     toast(LLM_BACKEND_HINT + ' — Settings (press 9)', 'error');
-            // For live mode, require an API key — unless local mode is on (llama.cpp/Ollama needs none)
-            if (mode === 'live' && !state.settings?.useLocal) {
-                const apiKey = getApiKey();
-                if (!apiKey || apiKey.length < 10) {
-                    toast('OpenRouter API key required for benchmarks — go to Settings (press 9) to configure, or enable the Local Model', 'error');
                     return;
                 }
             }
@@ -12418,9 +12387,6 @@ Penalize: wrong CWE identification, non-functional payloads, incomplete remediat
          * LLM-as-Judge - Semantic correctness evaluation
          * Uses a second LLM call to evaluate response quality
          */
-        async function runLLMJudge(test, response, apiKey) {
-            if (!EVALUATION_CONFIG.llmJudge.enabled || resolveLLMBackend().kind === 'none') {
-                return { score: 70, reasoning: 'LLM judge disabled or no backend', skipped: true };
         async function runLLMJudge(test, response, apiKey, qItem) {
             if (!EVALUATION_CONFIG.llmJudge.enabled || (!apiKey && !state.settings?.useLocal)) {
                 return { score: 70, reasoning: 'LLM judge disabled or no API key', skipped: true };
@@ -12627,11 +12593,6 @@ Respond with ONLY this JSON (no markdown, no extra text):
                             { role: 'system', content: systemPrompt },
                             { role: 'user', content: test.challenge }
                         ],
-                        { model: selectedModel, systemPrompt, maxTokens: 1000, temperature: opConfig?.params?.temperature || 0.3, timeout: 30000, title: 'T3MP3ST Benchmark' }
-                    );
-                } catch (err) {
-                    addIntel('API', `Error: ${String(err.message).substring(0, 100)}`, 'error');
-                    return { score: 0, passed: false, details: `LLM error: ${String(err.message).substring(0, 120)}`, response: String(err.message) };
                         {
                             model: selectedModel,
                             maxTokens: 1000,
@@ -12887,11 +12848,6 @@ Respond with ONLY this JSON (no markdown, no extra text):
             const hasBackend = resolveLLMBackend().kind !== 'none';
             const autoApplyBtn = document.getElementById('autoApplyBtn');
             if (hasBackend && analysis.improvements.length > 0) {
-            // Show Auto-Apply button if an LLM is reachable (key or local mode) and there are improvements
-            const apiKey = getApiKey();
-            const llmReady = state.settings?.useLocal || (apiKey && apiKey.length > 10);
-            const autoApplyBtn = document.getElementById('autoApplyBtn');
-            if (llmReady && analysis.improvements.length > 0) {
                 autoApplyBtn.style.display = 'inline-block';
             } else {
                 autoApplyBtn.style.display = 'none';
@@ -13152,12 +13108,6 @@ Respond with ONLY this JSON (no markdown, no extra text):
             if (resolveLLMBackend().kind === 'none') {
                 toast(LLM_BACKEND_HINT, 'error');
                 return;
-            if (!state.settings?.useLocal) {
-                const apiKey = getApiKey();
-                if (!apiKey || apiKey.length < 10) {
-                    toast('API key required for auto-apply, or enable the Local Model', 'error');
-                    return;
-                }
             }
 
             const analysis = window.lastAnalysis;
@@ -13249,10 +13199,6 @@ IMPORTANT:
 
                 const model = state.settings?.selectedModel || 'anthropic/claude-opus-4.6';
 
-                const content = await safeLLMCall(
-                    [{ role: 'user', content: prompt }],
-                    { model, temperature: 0.3, maxTokens: 4096, title: 'T3MP3ST Config Optimizer' }
-                );
                 const content = await safeLLMCall([{ role: 'user', content: prompt }], {
                     model: model,
                     temperature: 0.3,
@@ -20142,12 +20088,6 @@ IMPORTANT: This is an authorized security testing/red team platform. All operati
             if (resolveLLMBackend().kind === 'none') {
                 toast(LLM_BACKEND_HINT, 'error');
                 return;
-            if (!state.settings?.useLocal) {
-                const apiKey = getApiKey();
-                if (!apiKey || apiKey.length < 10) {
-                    toast('Configure OpenRouter API key first, or enable the Local Model', 'error');
-                    return;
-                }
             }
 
             if (state.operators.length === 0) {
@@ -20721,13 +20661,6 @@ RULES:
 
                 let content;
                 try {
-                    content = await safeLLMCall(
-                        [{ role: 'user', content: prompt }],
-                        { model, temperature: 0.3, maxTokens: 2000, timeout: 25000, title: 'T3MP3ST Self-Improvement' }
-                    );
-                } catch (err) {
-                    console.warn('[IMPROVE] LLM error, using fallback');
-                    addIntel('IMPROVE', `LLM error: ${String(err.message).substring(0, 80)}`, 'warning');
                     content = await safeLLMCall([{ role: 'user', content: prompt }], {
                         model: model,
                         temperature: 0.3,
@@ -21655,7 +21588,6 @@ ${entries}
                     { role: 'system', content: systemPrompt },
                     { role: 'user', content: userPrompt }
                 ],
-                { model, systemPrompt, maxTokens: 2000, temperature: opConfig?.params?.temperature || 0.4, timeout: 60000, title: 'T3MP3ST CTF Range' }
                 {
                     model: model,
                     maxTokens: 2000,


### PR DESCRIPTION
## What & why

The War Room UI (`docs/index.html`) ships with syntax errors in its main
`<script>` block from several bad-merge artifacts. Any one of them is a hard
`SyntaxError` that discards the entire ~20k-line block, so `navigateTo` is
never defined and sidebar navigation (Settings, Arsenal, …) does nothing — the
UI is stuck on the War Room page. `npm run verify-claims` doesn't cover the UI,
so this slipped through.

## Changes

- Merge the two split `safeLLMCall` definitions into one: keep the complete
  model-fallback loop and restore the `backend` resolution + keyless
  agent/server branch it referenced but no longer defined.
- Remove premature/dead fetch and options fragments in `_safeLLMCallOnce`,
  `runBenchmarks`, `runLLMJudge`, `generateAnalysis`,
  `autoApplyRecommendations`, `runSelfImprovementLoop`, the benchmark
  evaluator, and the CTF call — keeping the newer `_noFallback` /
  `llmTimeoutFor` variant in each.

Net: +17 / −85 (dead-code removal).

## Verification

- Every `<script>` block passes a syntax check; bracket balance is even.
- Headless browser: `navigateTo` defined (global fn count 93 → 515), all 14
  nav pages switch, Settings renders, no console errors.

## Notes

Semantics are preserved to the newer of each duplicated pair; no behavior was
invented. Suggest adding a lightweight UI syntax-check (per `<script>` block)
to CI so this can't regress.
