### PR TITLE
fix(config): handle 'local-agent' provider in getLLMConfig

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -867,6 +867,12 @@ class ConfigManager {
       case 'codex':
         actualModel = model || this.config.get('codex').defaultModel;
         break;
+      case 'local-agent':
+        // Connected local agent CLI (Claude Code / Codex / Hermes) used AS the LLM backend —
+        // keyless (each CLI uses its own login). The agent id (codex|claude|hermes) travels in
+        // `model`; default to 'codex' to match LocalAgentAdapter.chat (src/llm/index.ts).
+        actualModel = model || 'codex';
+        break;
       case 'mock':
         actualModel = 'mock-model';
         break;
@@ -978,6 +984,10 @@ class ConfigManager {
         break;
       case 'codex':
         this.config.set('defaultModel', this.config.get('codex').defaultModel);
+        break;
+      case 'local-agent':
+        // No stored provider block — default agent id is 'codex' (matches LocalAgentAdapter.chat).
+        this.config.set('defaultModel', 'codex');
         break;
       case 'local':
         this.config.set('defaultModel', process.env.TEMPEST_LOCAL_MODEL?.trim() || 'llama3');


### PR DESCRIPTION
## What changed

`ConfigManager.getLLMConfig` (src/config/index.ts) had a `switch` over
provider names with a `default:` that threw `Unknown provider:
${actualProvider}`. The `LLMProvider` type union includes `'local-agent'`
(Claude Code / Codex / Hermes CLI backends), and the UI correctly sends
`provider='local-agent'`, but the switch had no `case 'local-agent':` —
so any mission dispatched with that provider fell through to the throw.
The UI showed the agent as "connected" (the health-check uses a separate
in-memory registry, `connectedLocalAgents`), but the mission was refused
with:

  Refused: the live-tools backend failed: Unknown provider: local-agent

A prior workaround at `server.ts:6168` swallowed the throw inside
`/api/models` (comment: "getLLMConfig throws for...the legitimate
'local-agent'"), but the root cause remained — so other call sites that
resolve LLM config without the `resolveGeneralLLMConfig` short-circuit
(`recon/whitebox.ts`, the default-config resolver, the mission path when
a base URL is supplied) still crashed.

## Why it changed

Selecting a connected local agent (e.g. Hermes) as the LLM backend is a
first-class, keyless path in the UI and the `LocalAgentAdapter`
(`src/llm/index.ts:1294`), but the config resolver rejected it. The fix
makes `'local-agent'` a first-class case in `getLLMConfig` and
`setDefaultProvider`, matching how `codex` (the other keyless local-CLI
provider) is already handled — minus the stored provider block, since
local-agent has no apiKey/baseUrl.

## What the change does

- `getLLMConfig`: `case 'local-agent':` sets `actualModel = model || 'codex'`.
  The agent id (codex|claude|hermes) travels in `model`; default `'codex'`
  matches `LocalAgentAdapter.chat` (src/llm/index.ts:1317). No apiKey or
  baseUrl is set — keyless, each CLI uses its own login.
- `setDefaultProvider`: `case 'local-agent':` sets `defaultModel` to
  `'codex'` so selecting it as the default is not a silent no-op.

No change to `LocalAgentAdapter`, `requireLiveLocalAgent`, the connected-
agent registry, or the `resolveGeneralLLMConfig` short-circuit at
`server.ts:6823` — they were already correct; they just couldn't be
reached reliably because the config resolver threw first.

## Commands run

- `npm run typecheck` -> pass
- `npm test` -> pass (30/30: vitest src, ops preflight 11, model-matrix 19)
- `npm run doctor` -> pass (offline API health endpoint is pre-existing, unrelated)
- `npm run verify-claims` -> pass (27/27)
- `npm run lint` -> pass (0 errors, 128 pre-existing warnings unchanged)
- `npm run build` -> pass

## Scope audit

`git diff --name-status main...HEAD`:
  M src/config/index.ts

Single file, 10 insertions. No benchmark, provenance, provider-config,
redaction, or safety-test paths touched.

## Contribution Receipt

- Change: Add `case 'local-agent':` to `ConfigManager.getLLMConfig` and
  `setDefaultProvider` so the keyless local-agent CLI backend (Claude
  Code / Codex / Hermes) resolves like other providers instead of
  throwing `Unknown provider: local-agent`.
- Scope class: local_lab
- Target authority: not_applicable (config resolver fix; no target touched)
- Network use: none
- Run mode labels: local_agent, planning_only (no execution path changed)
- Model/harness labels: model=not_applicable, provider=local-agent,
  agent_runtime=Claude Code/Codex/Hermes, harness=getLLMConfig,
  tool_access=none, target_class=static_fixture, run_mode=planning_only,
  attempts=0, successes=0, failures=0, abstentions=0
- Commands run:
  - `npm run typecheck` -> pass
  - `npm test` -> pass (30/30)
  - `npm run doctor` -> pass
  - `npm run verify-claims` -> pass (27/27)
- Artifacts: none (config-only fix; no benchmark artifacts introduced)
- Redaction: none needed (no secrets, tokens, flags, or target data in diff)
- Claims changed: none
- Abstentions/refusals: 0 (the bug *caused* a refusal-like error; the fix removes it)
- Residual risk: `setDefaultModel('local-agent', ...)` still falls through
  the second switch as a no-op — intentional, since local-agent has no
  stored provider block to merge a defaultModel into, and the agent id is
  always passed directly in `model` at call time. No behavior change vs.
  pre-fix for that path.