### PR TITLE
fix(llm): populate usage for the Claude Code local-agent path

### DIFF
--- a/src/__tests__/local-agent-tool-calling.test.ts
+++ b/src/__tests__/local-agent-tool-calling.test.ts
@@ -34,6 +34,7 @@ const TOOLS = [{
   parameters: { type: 'object' as const, properties: { target: { type: 'string' } }, required: ['target'] },
 }];
 const localBackbone = () => new LLMBackbone({ provider: 'local-agent', model: 'codex' } as never);
+const claudeBackbone = () => new LLMBackbone({ provider: 'local-agent', model: 'claude' } as never);
 const codexBackbone = () => new LLMBackbone({ provider: 'codex', model: 'codex-default' } as never);
 
 describe('parseTextToolCalls — happy path + drift tolerance', () => {
@@ -133,6 +134,64 @@ describe('local-agent backbone surfaces toolCalls (keyless-path fix)', () => {
       .chat([{ role: 'user', content: 'hello' }]);
     expect(cli.mock.calls.at(-1)?.[0]).toBe('claude');
     expect(cli.mock.calls.at(-1)?.[2]?.model).toBeUndefined();
+  });
+});
+
+describe('Claude local-agent usage accounting (#139)', () => {
+  it('extracts content and aggregates real input, output, and cache token usage', async () => {
+    cli.mockResolvedValueOnce(JSON.stringify({
+      result: 'done',
+      usage: {
+        input_tokens: 11,
+        output_tokens: 7,
+        cache_creation_input_tokens: 13,
+        cache_read_input_tokens: 17,
+      },
+    }));
+
+    const res = await claudeBackbone().chat([{ role: 'user', content: 'hello' }]);
+
+    expect(res.content).toBe('done');
+    expect(res.usage).toEqual({ promptTokens: 41, completionTokens: 7, totalTokens: 48 });
+  });
+
+  it.each([
+    ['missing', { result: 'fallback' }],
+    ['empty', { result: 'fallback', usage: {} }],
+    ['zero', { result: 'fallback', usage: { input_tokens: 0, output_tokens: 0 } }],
+    ['malformed', { result: 'fallback', usage: { input_tokens: 'many', output_tokens: 2 } }],
+    ['negative', { result: 'fallback', usage: { input_tokens: -1, output_tokens: 2 } }],
+  ])('retains envelope content and estimates when usage is %s', async (_case, envelope) => {
+    cli.mockResolvedValueOnce(JSON.stringify(envelope));
+
+    const res = await claudeBackbone().chat([{ role: 'user', content: 'hello' }]);
+
+    expect(res.content).toBe('fallback');
+    expect(res.usage?.promptTokens).toBeGreaterThan(0);
+    expect(res.usage?.completionTokens).toBe(Math.ceil('fallback'.length / 4));
+    expect(res.usage?.totalTokens).toBe((res.usage?.promptTokens || 0) + (res.usage?.completionTokens || 0));
+  });
+
+  it('estimates usage and preserves raw content when the CLI does not return JSON', async () => {
+    cli.mockResolvedValueOnce('plain reply');
+
+    const res = await claudeBackbone().chat([{ role: 'user', content: 'hello' }]);
+
+    expect(res.content).toBe('plain reply');
+    expect(res.usage?.totalTokens).toBeGreaterThan(0);
+  });
+
+  it('parses tool calls from the JSON result rather than the envelope', async () => {
+    cli.mockResolvedValueOnce(JSON.stringify({
+      result: '{"tool_calls":[{"name":"nmap_scan","arguments":{"target":"x"}}]}',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    }));
+
+    const res = await claudeBackbone().chatWithTools([{ role: 'user', content: 'scan' }], TOOLS as never);
+
+    expect(res.toolCalls?.[0]?.name).toBe('nmap_scan');
+    expect(res.finishReason).toBe('tool_calls');
+    expect(res.usage?.totalTokens).toBe(15);
   });
 });
 

--- a/src/agent/local-agents.ts
+++ b/src/agent/local-agents.ts
@@ -469,7 +469,10 @@ export function localAgentChat(id: string, prompt: string, opts: { model?: strin
   let outFile: string | null = null;
   let workDir: string | null = null;
   if (id === 'claude') {
-    args = ['-p', '--output-format', 'text', ...(model ? ['--model', model] : [])];
+    // json (not text): the envelope carries REAL per-call token usage (input/output tokens
+    // plus prompt-cache creation/read) that LocalAgentAdapter.chat() parses to drive
+    // AgentLoop's token budget check. text mode reports no usage at all.
+    args = ['-p', '--output-format', 'json', ...(model ? ['--model', model] : [])];
   } else if (id === 'codex') {
     workDir = mkdtempSync(join(tmpdir(), 't3mp3st-codexllm-'));
     outFile = join(workDir, 'reply.txt');

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1305,8 +1305,8 @@ interface ClaudeJsonEnvelope {
   };
 }
 
-/** Parse the envelope; null (not thrown) on anything unexpected so the caller can fall back. */
-function parseClaudeJsonEnvelope(raw: string): { content: string; usage: LLMResponse['usage'] } | null {
+/** Parse the envelope; invalid usage is omitted so the caller can retain content and estimate. */
+function parseClaudeJsonEnvelope(raw: string): { content: string; usage?: LLMResponse['usage'] } | null {
   let json: ClaudeJsonEnvelope;
   try {
     json = JSON.parse(raw);
@@ -1315,8 +1315,14 @@ function parseClaudeJsonEnvelope(raw: string): { content: string; usage: LLMResp
   }
   if (typeof json.result !== 'string') return null;
   const u = json.usage || {};
-  const promptTokens = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
-  const completionTokens = u.output_tokens || 0;
+  const tokenValues = [u.input_tokens, u.output_tokens, u.cache_creation_input_tokens, u.cache_read_input_tokens];
+  if (!tokenValues.some((v) => v !== undefined)
+      || tokenValues.some((v) => v !== undefined && (!Number.isFinite(v) || v < 0))) {
+    return { content: json.result };
+  }
+  const promptTokens = (u.input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0);
+  const completionTokens = u.output_tokens ?? 0;
+  if (promptTokens + completionTokens === 0) return { content: json.result };
   return { content: json.result, usage: { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens } };
 }
 
@@ -1374,7 +1380,9 @@ class LocalAgentAdapter implements LLMProviderAdapter {
     // additionally gets a character-based usage ESTIMATE so its budget check is never blind again.
     const parsed = agentId === 'claude' ? parseClaudeJsonEnvelope(raw) : null;
     const content = parsed ? parsed.content : raw;
-    const usage = parsed ? parsed.usage : (agentId === 'claude' ? estimateUsage(prompt, raw) : undefined);
+    const usage = agentId === 'claude'
+      ? (parsed?.usage ?? estimateUsage(prompt, parsed?.content ?? raw))
+      : undefined;
     // Tool-calling over text: if the Arsenal was offered, parse the agent's tool requests so the
     // ReAct loop EXECUTES them instead of treating this planning turn as the (abstaining) final answer.
     const toolCalls = options?.tools?.length ? parseTextToolCalls(content) : undefined;

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1290,6 +1290,45 @@ class CodexAdapter implements LLMProviderAdapter {
   }
 }
 
+// Claude Code's `--output-format json` envelope (requested only for agentId 'claude', see
+// localAgentChat in local-agents.ts). Carries REAL per-call token accounting straight from the
+// CLI — input/output tokens plus the prompt-cache creation/read tokens from Claude Code's own
+// bootstrap (CLAUDE.md, skills, MCP tool manifests), which a text-length estimate has no way to
+// see and which measured 4-25k tokens on a single trivial call in testing.
+interface ClaudeJsonEnvelope {
+  result?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+/** Parse the envelope; null (not thrown) on anything unexpected so the caller can fall back. */
+function parseClaudeJsonEnvelope(raw: string): { content: string; usage: LLMResponse['usage'] } | null {
+  let json: ClaudeJsonEnvelope;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof json.result !== 'string') return null;
+  const u = json.usage || {};
+  const promptTokens = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
+  const completionTokens = u.output_tokens || 0;
+  return { content: json.result, usage: { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens } };
+}
+
+// Character-based fallback ONLY — used when the real envelope can't be parsed (older CLI,
+// unexpected output shape). Rough on purpose: the goal is to give AgentLoop's budget check SOME
+// number instead of a permanently-zero one, not to be precise.
+function estimateUsage(promptText: string, completionText: string): LLMResponse['usage'] {
+  const promptTokens = Math.ceil(promptText.length / 4);
+  const completionTokens = Math.ceil(completionText.length / 4);
+  return { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens };
+}
+
 // Generic adapter that drives a CONNECTED local agent CLI (Claude Code / Codex / Hermes) as the LLM
 // backend — NO API key needed; each CLI uses its own login. The agent id travels in `config.model`,
 // optionally with an underlying model after a `::` separator ("claude::opus", "claude::claude-opus-4-8")
@@ -1329,7 +1368,13 @@ class LocalAgentAdapter implements LLMProviderAdapter {
     const { agentId, agentModel } = this.parseAgentSpec();
     const prompt = this.formatPrompt(messages, options);
     const timeoutMs = typeof this.config.timeout === 'number' && this.config.timeout > 0 ? this.config.timeout : undefined;
-    const content = (await localAgentChat(agentId, prompt, { model: agentModel, timeoutMs })).trim();
+    const raw = (await localAgentChat(agentId, prompt, { model: agentModel, timeoutMs })).trim();
+    // Claude requests --output-format json (see local-agents.ts) so this parses to REAL usage.
+    // Anything else (parse failure, or a non-claude agent) falls back to the raw text — claude
+    // additionally gets a character-based usage ESTIMATE so its budget check is never blind again.
+    const parsed = agentId === 'claude' ? parseClaudeJsonEnvelope(raw) : null;
+    const content = parsed ? parsed.content : raw;
+    const usage = parsed ? parsed.usage : (agentId === 'claude' ? estimateUsage(prompt, raw) : undefined);
     // Tool-calling over text: if the Arsenal was offered, parse the agent's tool requests so the
     // ReAct loop EXECUTES them instead of treating this planning turn as the (abstaining) final answer.
     const toolCalls = options?.tools?.length ? parseTextToolCalls(content) : undefined;
@@ -1338,6 +1383,7 @@ class LocalAgentAdapter implements LLMProviderAdapter {
       model: `local-agent:${agentId}${agentModel ? '/' + agentModel : ''}`,
       finishReason: toolCalls?.length ? 'tool_calls' : 'stop',
       toolCalls,
+      usage,
     };
   }
 }


### PR DESCRIPTION
Fixes #139.

`LocalAgentAdapter.chat()` never set `usage` on its `LLMResponse` for the Claude Code local-agent path, so `AgentLoop`'s per-task token budget check always compared against zero and never fired. `localAgentChat()` now requests `--output-format json` for the `claude` agent id only; `LocalAgentAdapter` parses the real envelope into `usage.promptTokens`/`completionTokens`, with a character-based estimate as a fallback if parsing fails. Codex and Hermes are untouched.

## Contribution Receipt
- Change: **Populate per-call usage for the Claude Code local-agent path (`--output-format json`) so `AgentLoop`'s token budget check can fire.**
- Scope class: local_lab
- Target authority: not_applicable (LLM backbone plumbing only; verification used a throwaway loopback fixture, not an authorized external target)
- Network use: loopback (verification target was a local throwaway HTTP server; the Claude Code CLI itself makes outbound calls to Anthropic under the operator's own account, inherent to exercising this adapter, not target network use)
- Run mode labels: local_agent, tool_backed
- Model/harness labels: model=claude-sonnet-5, provider=Anthropic (via Claude Code CLI, no API key), agent_runtime=Claude Code, harness=manual-review (ad hoc verification script, not a committed bench harness), tool_access=local_only
- Commands run:
  - `npm run typecheck` -> pass
  - `npm test` -> pass (675/675 vitest, 11/11 ops-preflight, 19/19 model-matrix)
  - `npm run doctor` -> pass (30/33, 3 warnings: semgrep/promptfoo missing, API health offline with the server not running — no blockers)
  - `npm run verify-claims` -> pass (27/27, no headline numbers changed)
- Artifacts: none committed. Verification used an ad hoc script (deleted after use) against a throwaway loopback HTTP fixture, plus two direct `claude -p --output-format json` calls confirming the envelope shape.
- Redaction: not_applicable (no secrets or evidence involved)
- Claims changed: none
- Abstentions/refusals: none
- Residual risk: Codex and Hermes local-agent paths are untouched and unverified (this fix targets `claude` only). The character-based fallback estimate (used only if the JSON envelope fails to parse) is a rough approximation, not exact. `agentFailureOutput`'s plain-text failure detection in `local-agents.ts` is not updated for JSON-wrapped error envelopes (pre-existing behavior, unchanged here).
