### PR TITLE
feat(binary): detect memcpy/memmove with a non-constant length

### DIFF
--- a/bench/binary-vulns/corpus.json
+++ b/bench/binary-vulns/corpus.json
@@ -44,6 +44,20 @@
       "content": "void fmt(char *input) {\n  char b[16];\n  sprintf(b, \"%s\", input);\n}\n"
     },
     {
+      "id": "memcpy-wire-length",
+      "desc": "memcpy with an attacker/wire-controlled length (unchecked) — buffer overflow",
+      "clean": false,
+      "expect": ["B-MEMCPY"],
+      "content": "void parse(char *pkt) {\n  char buf[128];\n  unsigned len = ntohl(*(unsigned *)pkt);\n  memcpy(buf, pkt + 4, len);\n}\n"
+    },
+    {
+      "id": "memcpy-bounded-control",
+      "desc": "Safe control — memcpy bounded by sizeof and by a constant length",
+      "clean": true,
+      "expect": [],
+      "content": "void copy(char *src) {\n  char dst[64];\n  memcpy(dst, src, sizeof(dst));\n  char hdr[4];\n  memcpy(hdr, src, 4);\n}\n"
+    },
+    {
       "id": "bounded-control",
       "desc": "Safe control — bounded strncpy/snprintf/fgets",
       "clean": true,

--- a/scripts/binary-vuln-bench.mjs
+++ b/scripts/binary-vuln-bench.mjs
@@ -26,6 +26,13 @@ export const RULES = [
   { id: 'B-FORMAT-STRING', desc: 'printf(var) — user-controlled format string', test: rx(/\bf?printf\s*\(\s*[a-zA-Z_]\w*\s*\)/) },
   { id: 'B-CMD-INJECTION', desc: 'system()/popen() on a variable — command injection', test: rx(/\b(system|popen)\s*\(\s*[a-zA-Z_]\w*/) },
   { id: 'B-INT-OVERFLOW', desc: 'malloc/calloc with multiplication — integer-overflow alloc size', test: rx(/\b(malloc|calloc|alloca|realloc)\s*\([^)]*\*/) },
+  // Inspects the length (3rd) arg: fires on a variable / field / deref / computed
+  // length (`len`, `hdr->len`, `ntohl(hdr->len)`), stays silent when it is a
+  // `sizeof(...)` expression or a numeric literal. The `[^)\s]` after the lookahead
+  // is load-bearing — without it `\s*` backtracks onto whitespace and every bounded
+  // form leaks through. Decompiled output inlines constants, so a named-macro length
+  // does not arise here.
+  { id: 'B-MEMCPY', desc: 'memcpy()/memmove() with a non-constant length — candidate overflow from an unchecked/wire-controlled size', test: rx(/\b(?:memcpy|memmove)\s*\([^,]+,[^,]+,\s*(?!\d|sizeof\b)[^)\s][^)]*\)/) },
 ];
 
 export function loadCorpus() {

--- a/scripts/binary-vuln-bench.mjs
+++ b/scripts/binary-vuln-bench.mjs
@@ -26,13 +26,19 @@ export const RULES = [
   { id: 'B-FORMAT-STRING', desc: 'printf(var) — user-controlled format string', test: rx(/\bf?printf\s*\(\s*[a-zA-Z_]\w*\s*\)/) },
   { id: 'B-CMD-INJECTION', desc: 'system()/popen() on a variable — command injection', test: rx(/\b(system|popen)\s*\(\s*[a-zA-Z_]\w*/) },
   { id: 'B-INT-OVERFLOW', desc: 'malloc/calloc with multiplication — integer-overflow alloc size', test: rx(/\b(malloc|calloc|alloca|realloc)\s*\([^)]*\*/) },
-  // Inspects the length (3rd) arg: fires on a variable / field / deref / computed
-  // length (`len`, `hdr->len`, `ntohl(hdr->len)`), stays silent when it is a
-  // `sizeof(...)` expression or a numeric literal. The `[^)\s]` after the lookahead
-  // is load-bearing — without it `\s*` backtracks onto whitespace and every bounded
-  // form leaks through. Decompiled output inlines constants, so a named-macro length
-  // does not arise here.
-  { id: 'B-MEMCPY', desc: 'memcpy()/memmove() with a non-constant length — candidate overflow from an unchecked/wire-controlled size', test: rx(/\b(?:memcpy|memmove)\s*\([^,]+,[^,]+,\s*(?!\d|sizeof\b)[^)\s][^)]*\)/) },
+  // Inspects the length (3rd) arg: fires when it begins with a variable / field /
+  // deref / decoded value (`len`, `hdr->len`, `ntohl(hdr->len)`) and stays silent
+  // when it begins with a `sizeof` expression or a numeric literal. Two subtleties:
+  // the `[^)\s]` after the lookahead is load-bearing — without it `\s*` backtracks
+  // onto whitespace and bounded forms leak through; and args 1-2 are `[^,()]+` (no
+  // nested parens) so a comma inside a nested call can't mis-split the list into a
+  // false positive on a bounded call. Directional static pre-filter, not taint
+  // analysis — disclosed misses (silently NOT flagged): a computed length that
+  // starts with a digit (`8*count`) or with `sizeof` plus a term (`sizeof(x)+n`), a
+  // memcpy whose 1st/2nd arg is itself a call, an inline block comment before the
+  // length, and the `__memcpy_chk`/`memcpy_s`/`wmemcpy` variants. Decompiled output
+  // inlines constants, so a named-macro length does not arise here.
+  { id: 'B-MEMCPY', desc: 'memcpy()/memmove() with a non-constant length — candidate overflow from an unchecked/wire-controlled size', test: rx(/\b(?:memcpy|memmove)\s*\([^,()]+,[^,()]+,\s*(?!\d|sizeof\b)[^)\s][^)]*\)/) },
 ];
 
 export function loadCorpus() {

--- a/scripts/binary-vuln-bench.mjs
+++ b/scripts/binary-vuln-bench.mjs
@@ -30,15 +30,20 @@ export const RULES = [
   // deref / decoded value (`len`, `hdr->len`, `ntohl(hdr->len)`) and stays silent
   // when it begins with a `sizeof` expression or a numeric literal. Two subtleties:
   // the `[^)\s]` after the lookahead is load-bearing — without it `\s*` backtracks
-  // onto whitespace and bounded forms leak through; and args 1-2 are `[^,()]+` (no
-  // nested parens) so a comma inside a nested call can't mis-split the list into a
-  // false positive on a bounded call. Directional static pre-filter, not taint
-  // analysis — disclosed misses (silently NOT flagged): a computed length that
-  // starts with a digit (`8*count`) or with `sizeof` plus a term (`sizeof(x)+n`), a
-  // memcpy whose 1st/2nd arg is itself a call, an inline block comment before the
-  // length, and the `__memcpy_chk`/`memcpy_s`/`wmemcpy` variants. Decompiled output
-  // inlines constants, so a named-macro length does not arise here.
-  { id: 'B-MEMCPY', desc: 'memcpy()/memmove() with a non-constant length — candidate overflow from an unchecked/wire-controlled size', test: rx(/\b(?:memcpy|memmove)\s*\([^,()]+,[^,()]+,\s*(?!\d|sizeof\b)[^)\s][^)]*\)/) },
+  // onto whitespace and bounded forms leak through; and args 1-2 are matched with a
+  // single level of BALANCED parens `(?:[^,()]|\([^()]*\))+` so a cast `(void *)dst`
+  // and a comma-bearing call `get(a,b)` are each consumed as ONE arg — neither
+  // mis-splits the list (the original naive `[^,]+` split on the comma inside a
+  // call and false-fired on a bounded length). Directional static pre-filter, not
+  // taint analysis — disclosed misses (silently NOT flagged): a computed length
+  // that starts with a digit (`8*count`) or with `sizeof` plus a term
+  // (`sizeof(x)+n`), and a 1st/2nd arg with a DOUBLY-nested paren
+  // (`wrap(get(a,b))`). The `__memcpy_chk`/`memcpy_s`/`wmemcpy` variants are out of
+  // scope (the `\b...\(` shape); the `_chk` form is usually the bounded, safe one.
+  // Comments aren't stripped: a mid-argument `/* ... */` obscuring a sizeof/literal
+  // length would false-fire, but decompiled output does not emit inline comments.
+  // Decompiled output inlines constants, so a named-macro length does not arise.
+  { id: 'B-MEMCPY', desc: 'memcpy()/memmove() with a non-constant length — candidate overflow from an unchecked/wire-controlled size', test: rx(/\b(?:memcpy|memmove)\s*\((?:[^,()]|\([^()]*\))+,\s*(?:[^,()]|\([^()]*\))+,\s*(?!\d|sizeof\b)[^)\s][^)]*\)/) },
 ];
 
 export function loadCorpus() {

--- a/src/__tests__/binary-vuln-bench.test.ts
+++ b/src/__tests__/binary-vuln-bench.test.ts
@@ -32,9 +32,23 @@ describe('binary/RE decompiled-vuln benchmark', () => {
     expect(detect('printf(user);').has('B-FORMAT-STRING')).toBe(true);
   });
 
+  it('flags memcpy/memmove with a non-constant length, not a bounded one', () => {
+    // fires on a variable / wire-controlled / computed length
+    expect(detect('memcpy(buf, pkt + 4, len);').has('B-MEMCPY')).toBe(true);
+    expect(detect('memcpy(dst, src, hdr->len);').has('B-MEMCPY')).toBe(true);
+    expect(detect('memcpy(dst, src, ntohl(hdr->len));').has('B-MEMCPY')).toBe(true);
+    expect(detect('memmove(d, s, n);').has('B-MEMCPY')).toBe(true);
+    // stays silent when the length is sizeof-bounded or a numeric literal —
+    // this is what forces a discriminating rule rather than a bare /memcpy/ match
+    expect(detect('memcpy(dst, src, sizeof(dst));').has('B-MEMCPY')).toBe(false);
+    expect(detect('memcpy(hdr, src, 4);').has('B-MEMCPY')).toBe(false);
+    expect(detect('memcpy(dst, src, 0x40);').has('B-MEMCPY')).toBe(false);
+  });
+
   it('ruleset spans memory-safety + injection + integer-overflow', () => {
     expect(RULES.length).toBeGreaterThanOrEqual(6);
     expect(RULES.some((r) => r.id === 'B-CMD-INJECTION')).toBe(true);
     expect(RULES.some((r) => r.id === 'B-INT-OVERFLOW')).toBe(true);
+    expect(RULES.some((r) => r.id === 'B-MEMCPY')).toBe(true);
   });
 });

--- a/src/__tests__/binary-vuln-bench.test.ts
+++ b/src/__tests__/binary-vuln-bench.test.ts
@@ -33,16 +33,33 @@ describe('binary/RE decompiled-vuln benchmark', () => {
   });
 
   it('flags memcpy/memmove with a non-constant length, not a bounded one', () => {
-    // fires on a variable / wire-controlled / computed length
-    expect(detect('memcpy(buf, pkt + 4, len);').has('B-MEMCPY')).toBe(true);
-    expect(detect('memcpy(dst, src, hdr->len);').has('B-MEMCPY')).toBe(true);
-    expect(detect('memcpy(dst, src, ntohl(hdr->len));').has('B-MEMCPY')).toBe(true);
-    expect(detect('memmove(d, s, n);').has('B-MEMCPY')).toBe(true);
-    // stays silent when the length is sizeof-bounded or a numeric literal —
-    // this is what forces a discriminating rule rather than a bare /memcpy/ match
-    expect(detect('memcpy(dst, src, sizeof(dst));').has('B-MEMCPY')).toBe(false);
-    expect(detect('memcpy(hdr, src, 4);').has('B-MEMCPY')).toBe(false);
-    expect(detect('memcpy(dst, src, 0x40);').has('B-MEMCPY')).toBe(false);
+    const fires = (c: string) => expect(detect(c).has('B-MEMCPY'), c).toBe(true);
+    const silent = (c: string) => expect(detect(c).has('B-MEMCPY'), c).toBe(false);
+
+    // fires on a variable / field / deref / wire-decoded / cast length
+    fires('memcpy(buf, pkt + 4, len);');
+    fires('memcpy(dst, src, hdr->len);');
+    fires('memcpy(dst, src, ntohl(hdr->len));');
+    fires('memmove(d, s, n);');
+    fires('memcpy(&d, s, (size_t)len);');
+    fires('memcpy(&local_38, param_1, size);');
+
+    // silent when the length is sizeof-bounded or a numeric literal — this is what
+    // forces a discriminating rule rather than a bare /memcpy/ match
+    silent('memcpy(dst, src, sizeof(dst));');
+    silent('memcpy(hdr, src, 4);');
+    silent('memcpy(dst, src, 0x40);');
+    silent('memcpy(dst, src, sizeof(struct hdr));');
+    // a comma inside a nested call must NOT mis-split the arg list and false-fire
+    // on a bounded sizeof length (args 1-2 are paren-free by construction)
+    silent('memcpy(dst, get_src(a,b), sizeof(dst));');
+
+    // Disclosed directional limits (see the rule comment): these non-constant
+    // lengths are NOT flagged — pinned here so the scope boundary is auditable and
+    // any future tightening surfaces as a deliberate change, not a silent one.
+    silent('memcpy(d, s, 8 * count);'); //         leading-digit computed length
+    silent('memcpy(d, s, sizeof(x) + n);'); //     sizeof plus a variable term
+    silent('memcpy(get_dst(a,b), src, len);'); //  1st/2nd arg is itself a call
   });
 
   it('ruleset spans memory-safety + injection + integer-overflow', () => {

--- a/src/__tests__/binary-vuln-bench.test.ts
+++ b/src/__tests__/binary-vuln-bench.test.ts
@@ -43,6 +43,13 @@ describe('binary/RE decompiled-vuln benchmark', () => {
     fires('memmove(d, s, n);');
     fires('memcpy(&d, s, (size_t)len);');
     fires('memcpy(&local_38, param_1, size);');
+    // pointer casts on args 1-2 are the common decompiled shape — must still fire
+    fires('memcpy((void *)dst, src, len);');
+    fires('memmove((uint8_t *)dst, (uint8_t *)src, len);');
+    fires('memcpy((char *)dst + 4, src, len);');
+    // a comma-bearing call in an arg is consumed as one arg, so a non-constant
+    // length after it is still caught
+    fires('memcpy(get_dst(a,b), src, len);');
 
     // silent when the length is sizeof-bounded or a numeric literal — this is what
     // forces a discriminating rule rather than a bare /memcpy/ match
@@ -51,15 +58,18 @@ describe('binary/RE decompiled-vuln benchmark', () => {
     silent('memcpy(dst, src, 0x40);');
     silent('memcpy(dst, src, sizeof(struct hdr));');
     // a comma inside a nested call must NOT mis-split the arg list and false-fire
-    // on a bounded sizeof length (args 1-2 are paren-free by construction)
+    // on a bounded sizeof length; casts on args 1-2 must not either
     silent('memcpy(dst, get_src(a,b), sizeof(dst));');
+    silent('memcpy((void *)dst, (void *)src, sizeof(dst));');
 
     // Disclosed directional limits (see the rule comment): these non-constant
     // lengths are NOT flagged — pinned here so the scope boundary is auditable and
     // any future tightening surfaces as a deliberate change, not a silent one.
-    silent('memcpy(d, s, 8 * count);'); //         leading-digit computed length
-    silent('memcpy(d, s, sizeof(x) + n);'); //     sizeof plus a variable term
-    silent('memcpy(get_dst(a,b), src, len);'); //  1st/2nd arg is itself a call
+    silent('memcpy(d, s, 8 * count);'); //          leading-digit computed length
+    silent('memcpy(d, s, sizeof(x) + n);'); //      sizeof plus a variable term
+    silent('memcpy(dst, wrap(get(a,b)), len);'); // doubly-nested paren in an arg
+    silent('__memcpy_chk(dst, src, len, dn);'); //  _chk variant (usually bounded)
+    silent('wmemcpy(dst, src, len);'); //           wide-char variant
   });
 
   it('ruleset spans memory-safety + injection + integer-overflow', () => {


### PR DESCRIPTION
Closes #150.

Adds `B-MEMCPY` to the Binary/RE decompiled-vuln detector (`scripts/binary-vuln-bench.mjs`) — flags `memcpy`/`memmove` calls whose length argument is **non-constant** (a variable, struct field, deref, or decoded value), the classic unbounded-copy overflow. `strcpy` was covered; its `memcpy(dst, src, len)` sibling was the gap.

## Why this one

The reasoning layer already treats this sink as its textbook target:

- `src/orchestration/prompts.ts:60` — refuses on "a wire-controlled length flowing into an **unchecked memcpy**"
- `src/orchestration/prompts.ts:80` — "the smoking-gun line (e.g. the **unchecked memcpy of a wire length**)"
- `src/orchestration/index.ts:11` — example question: "Does this function validate the length parameter before the **memcpy**?"

So the LLM adjudication layer is built around this pattern, but the fast static pre-filter couldn't surface it as a candidate at all.

## The rule

```js
{ id: 'B-MEMCPY', desc: 'memcpy()/memmove() with a non-constant length — candidate overflow from an unchecked/wire-controlled size',
  test: rx(/\b(?:memcpy|memmove)\s*\((?:[^,()]|\([^()]*\))+,\s*(?:[^,()]|\([^()]*\))+,\s*(?!\d|sizeof\b)[^)\s][^)]*\)/) },
```

It inspects the **third argument**: fires on `len` / `hdr->len` / `*p` / `ntohl(hdr->len)` / `(size_t)len`, stays silent on `sizeof(dst)` / `16` / `0x40`. Two subtleties are load-bearing and documented in-code: the `[^)\s]` after the lookahead stops `\s*` from backtracking onto whitespace (which would leak every bounded form through), and args 1–2 match a single level of **balanced parens** (`(?:[^,()]|\([^()]*\))+`) so a pointer cast `(void *)dst` and a comma-bearing call `get(a,b)` are each consumed as one arg — neither mis-splits the list into a false positive on a bounded length. (Pointer casts on args 1–2 are the common decompiled shape; the first cut used a paren-free arg matcher and missed them — caught by a second adversarial review pass.)

## Honest scope

This is a **directional static pre-filter over decompiled output** — a *candidate* sink, matching the existing corpus's stated posture. It is not taint analysis and does not prove the length is attacker-reachable (that is the reasoning layer's job). Disclosed misses, enumerated in the rule comment and pinned as tests so the boundary is auditable:

- a computed length that starts with a digit (`8*count`) or with `sizeof` plus a term (`sizeof(x)+n`)
- a 1st/2nd arg with a **doubly-nested** paren (`wrap(get(a,b))`)
- the `__memcpy_chk` / `memcpy_s` / `wmemcpy` variants (the `_chk` form is usually the bounded, safe one)

Each disclosed limit is pinned by a test so the boundary is auditable. Mid-argument `/* ... */` comments aren't stripped (a comment obscuring a `sizeof`/literal would false-fire), but decompiled output does not emit inline comments.

Out of scope for this rule, as separate follow-ups: `strcat`, exec-family injection, additive/shift overflow precursors.

## Tests — RED-first, discriminating

- **RED** (`a0b7198`): a bad fixture (`memcpy` with a wire-decoded length) and a **clean control with two safe memcpys** (`sizeof`-bounded + a constant length) go into the corpus, plus direct assertions. The clean control is what forces a real regex — a bare `/memcpy/` rule false-positives on it and fails the zero-false-positive gate, so the test isn't a tautology. Both fail on `main`.
- **GREEN** (`bf7b7d6`): the single `RULES` entry.
- **Hardened** (`12022c5`): a first adversarial review found a false positive on nested-call args (`memcpy(dst, get_src(a,b), sizeof(dst))` — a bounded call that fired); expanded the test into an in-tree fires/silent/disclosed-limit matrix.
- **Cast fix** (`966a46f`): a second adversarial review (on the shipped state) found the paren-free tightening had over-corrected and stopped matching pointer casts — the common decompiled shape. Switched args 1–2 to balanced-paren matching, which fixes the original FP and the cast miss together. Validated against a 31-case fuzz oracle + a ReDoS sanity check.

Corpus goes 6+2 → 7+3; the `>=6` floors stay satisfied.

## Verification (macOS, Apple Silicon)

- `node scripts/binary-vuln-bench.mjs` self-test: **7/7 seeded sinks caught, 3/3 controls clean, 0 false-positives.**
- `npm test`: **755 vitest tests green** (+ ops-preflight 11/11, model-matrix, refusal-frontier 19/19).
- `npm run typecheck`: clean. `eslint` on the changed TS test file: clean. (The `.mjs`'s pre-existing node-globals `no-undef` lint is unchanged by this diff and outside CI's `eslint src/**/*.ts` scope.)

macOS-neutral: the rule is a regex over committed text fixtures — no platform-specific behavior. I can only verify on macOS, so I'm not claiming Linux/Windows runs I didn't do.
