### PR TITLE
fix(obsidivm): actionable error when the range service is unreachable (#156)

### DIFF
--- a/scripts/obsidivm-bench.mjs
+++ b/scripts/obsidivm-bench.mjs
@@ -7,7 +7,9 @@
  *   2. Dispatch a t3mp3st hunter against the target's URL.
  *      - --hunter=live   : direct LLM (OpenRouter / Anthropic / OpenAI auto-detect)
  *      - --hunter=t3mp3st: drive t3mp3st's /api/general/auto (full platform)
- *      - --hunter=stub   : synthesized transcript (no LLM, for plumbing tests)
+ *      - --hunter=stub   : synthesized transcript (no LLM, for plumbing tests).
+ *                          NB: only the HUNTER is offline — the OBSIDIVM service
+ *                          is still required for the spec (step 1) and scoring (3).
  *   3. Submit the agent transcript to OBSIDIVM's /api/score/text.
  *   4. Persist the run via OBSIDIVM's /api/runs ledger + per-target sessions.
  *   5. Print a per-target table + suite aggregate (weighted % + grade).
@@ -105,9 +107,12 @@ function help() {
 Options:
   --target <id>           Target id (repeatable). Default: all 14 OBSIDIVM targets.
   --hunter <stub|live|t3mp3st>
-                          stub:    synthesized transcript (no LLM)
+                          stub:    synthesized transcript (no LLM; the OBSIDIVM
+                                   service is still required for spec + scoring)
                           live:    direct LLM call
                           t3mp3st: drive t3mp3st's /api/general/auto
+  All modes need the OBSIDIVM service (see --obsidivm / docs/OBSIDIVM.md); live
+  and t3mp3st additionally need an LLM key.
   --obsidivm <url>        OBSIDIVM base URL (default http://127.0.0.1:4200)
   --t3mp3st <url>         t3mp3st base URL (default http://127.0.0.1:3333)
   --model <name>          LLM model id (default claude-opus-4-7)

--- a/scripts/obsidivm-bridge.d.mts
+++ b/scripts/obsidivm-bridge.d.mts
@@ -24,6 +24,10 @@ export interface ObsidivmClient {
   proposeGoalposts(payload?: Record<string, unknown>): Promise<unknown>;
   evolveStart(payload?: Record<string, unknown>): Promise<unknown>;
   evolveStop(): Promise<unknown>;
+  cloudgoatInstall(): Promise<unknown>;
+  cloudgoatCreate(scenario: string): Promise<unknown>;
+  cloudgoatDestroy(scenario: string): Promise<unknown>;
+  cloudgoatDestroyAll(): Promise<unknown>;
 }
 
 export function obsidivm(opts?: { baseUrl?: string; timeoutMs?: number }): ObsidivmClient;

--- a/scripts/obsidivm-bridge.d.mts
+++ b/scripts/obsidivm-bridge.d.mts
@@ -1,0 +1,29 @@
+// Types for the OBSIDIVM bridge client (consumed by the vitest test).
+// Runnable logic lives in the sibling .mjs (scripts run under bare `node`, no build step).
+
+/** A network-level failure (connection refused / DNS / timeout) carries this flag,
+ * distinguishing an unreachable service from an HTTP-status error (which sets `status`). */
+export interface ObsidivmError extends Error {
+  unreachable?: boolean;
+  status?: number;
+  body?: unknown;
+}
+
+export interface ObsidivmClient {
+  readonly baseUrl: string;
+  health(): Promise<unknown>;
+  getSpec(): Promise<{ version?: string; targets?: Array<{ id: string; name?: string; port?: number }> } & Record<string, unknown>>;
+  status(): Promise<unknown>;
+  deploy(): Promise<unknown>;
+  destroy(): Promise<unknown>;
+  startTarget(id: string): Promise<unknown>;
+  stopTarget(id: string): Promise<unknown>;
+  scoreText(targetId: string, text: string): Promise<Record<string, unknown>>;
+  createRun(payload?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  attachSession(runId: string, payload?: Record<string, unknown>): Promise<unknown>;
+  proposeGoalposts(payload?: Record<string, unknown>): Promise<unknown>;
+  evolveStart(payload?: Record<string, unknown>): Promise<unknown>;
+  evolveStop(): Promise<unknown>;
+}
+
+export function obsidivm(opts?: { baseUrl?: string; timeoutMs?: number }): ObsidivmClient;

--- a/scripts/obsidivm-bridge.mjs
+++ b/scripts/obsidivm-bridge.mjs
@@ -40,12 +40,21 @@ export function obsidivm({ baseUrl, timeoutMs } = {}) {
           signal: ctrl.signal,
         });
       } catch (e) {
-        // The fetch itself failed (connection refused, DNS, timeout) — distinct
-        // from an HTTP-status error below. A bare `fetch failed` here is the #156
-        // dead-end; make it self-service instead. Timeout is the AbortController
-        // firing; anything else means nothing is listening on the base URL.
+        // The fetch itself failed — distinct from an HTTP-status error below. A
+        // bare `fetch failed` here is the #156 dead-end; make it self-service.
+        // Three sub-cases, kept distinct so the message points at the real fix:
+        //   AbortError      → the request timed out
+        //   ERR_INVALID_URL → OBSIDIVM_URL is malformed (a config error, NOT a
+        //                     down service — don't send the user to start one)
+        //   otherwise       → nothing is listening on the base URL
         if (e?.name === 'AbortError') {
           throw new Error(`OBSIDIVM ${method} ${path} timed out after ${t}ms (${base}).`);
+        }
+        if (e?.cause?.code === 'ERR_INVALID_URL') {
+          throw new Error(
+            `Invalid OBSIDIVM base URL ${JSON.stringify(base)} — set OBSIDIVM_URL (or --obsidivm) ` +
+              `to a full URL like http://127.0.0.1:4200.`,
+          );
         }
         const err = new Error(
           `OBSIDIVM service unreachable at ${base} — ${method} ${path} failed ` +

--- a/scripts/obsidivm-bridge.mjs
+++ b/scripts/obsidivm-bridge.mjs
@@ -31,12 +31,31 @@ export function obsidivm({ baseUrl, timeoutMs } = {}) {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), t);
     try {
-      const res = await fetch(url, {
-        method,
-        headers: body ? { 'content-type': 'application/json' } : {},
-        body: body ? JSON.stringify(body) : undefined,
-        signal: ctrl.signal,
-      });
+      let res;
+      try {
+        res = await fetch(url, {
+          method,
+          headers: body ? { 'content-type': 'application/json' } : {},
+          body: body ? JSON.stringify(body) : undefined,
+          signal: ctrl.signal,
+        });
+      } catch (e) {
+        // The fetch itself failed (connection refused, DNS, timeout) — distinct
+        // from an HTTP-status error below. A bare `fetch failed` here is the #156
+        // dead-end; make it self-service instead. Timeout is the AbortController
+        // firing; anything else means nothing is listening on the base URL.
+        if (e?.name === 'AbortError') {
+          throw new Error(`OBSIDIVM ${method} ${path} timed out after ${t}ms (${base}).`);
+        }
+        const err = new Error(
+          `OBSIDIVM service unreachable at ${base} — ${method} ${path} failed ` +
+            `(${e?.cause?.code || e?.message || 'network error'}). Is it running? ` +
+            `Start it per docs/OBSIDIVM.md (python3 range.py, listens on :4200), or set OBSIDIVM_URL.`,
+        );
+        err.unreachable = true;
+        err.cause = e;
+        throw err;
+      }
       const text = await res.text();
       let parsed;
       try { parsed = JSON.parse(text); } catch { parsed = { raw: text }; }

--- a/src/__tests__/obsidivm-bridge.test.ts
+++ b/src/__tests__/obsidivm-bridge.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Diagnostics guard for issue #156 — "Benchmark showing error" / `FATAL: fetch failed`.
+ *
+ * The obsidivm:* benchmarks are a thin HTTP client over the separate OBSIDIVM
+ * range service (default http://127.0.0.1:4200, see docs/OBSIDIVM.md). Every
+ * request routes through the bridge's `call()`. When the service is down, the
+ * raw `fetch` throws a bare `TypeError: fetch failed`, which surfaced to the user
+ * as an opaque `FATAL: fetch failed` naming neither the service, the URL, nor how
+ * to start it — even in `--hunter stub` mode, whose grading step still needs it.
+ *
+ * This pins that a connection failure becomes an ACTIONABLE error: it says the
+ * OBSIDIVM service is unreachable, names the base URL, and points at the escape
+ * hatches (docs/OBSIDIVM.md / OBSIDIVM_URL).
+ */
+import { describe, it, expect } from 'vitest';
+import net from 'node:net';
+import { obsidivm } from '../../scripts/obsidivm-bridge.mjs';
+
+/**
+ * A guaranteed-closed localhost port: bind an ephemeral listener, capture its
+ * port, then close it — a connection there now yields ECONNREFUSED,
+ * deterministically and with no external network (hermetic, no mocking).
+ */
+function closedPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address() as net.AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+describe('obsidivm bridge — unreachable-service diagnostics (#156)', () => {
+  it('turns a connection failure into an actionable error, not a bare "fetch failed"', async () => {
+    const port = await closedPort();
+    const o = obsidivm({ baseUrl: `http://127.0.0.1:${port}`, timeoutMs: 2000 });
+
+    const err = (await o.getSpec().then(() => null, (e) => e)) as (Error & { unreachable?: boolean }) | null;
+
+    expect(err, 'getSpec should reject when the service is down').toBeTruthy();
+    // names the failure, the URL, and the self-service escape hatches
+    expect(err!.message).toMatch(/OBSIDIVM service unreachable/i);
+    expect(err!.message).toContain(`127.0.0.1:${port}`);
+    expect(err!.message).toMatch(/OBSIDIVM_URL|docs\/OBSIDIVM\.md/);
+    // and is flagged so callers can distinguish "down" from an HTTP-status error
+    expect(err!.unreachable).toBe(true);
+  });
+});

--- a/src/__tests__/obsidivm-bridge.test.ts
+++ b/src/__tests__/obsidivm-bridge.test.ts
@@ -37,7 +37,7 @@ describe('obsidivm bridge — unreachable-service diagnostics (#156)', () => {
     const port = await closedPort();
     const o = obsidivm({ baseUrl: `http://127.0.0.1:${port}`, timeoutMs: 2000 });
 
-    const err = (await o.getSpec().then(() => null, (e) => e)) as (Error & { unreachable?: boolean }) | null;
+    const err = (await o.getSpec().then(() => null, (e: unknown) => e)) as (Error & { unreachable?: boolean }) | null;
 
     expect(err, 'getSpec should reject when the service is down').toBeTruthy();
     // names the failure, the URL, and the self-service escape hatches
@@ -46,5 +46,44 @@ describe('obsidivm bridge — unreachable-service diagnostics (#156)', () => {
     expect(err!.message).toMatch(/OBSIDIVM_URL|docs\/OBSIDIVM\.md/);
     // and is flagged so callers can distinguish "down" from an HTTP-status error
     expect(err!.unreachable).toBe(true);
+  });
+
+  it('reports a timeout distinctly (not as "unreachable")', async () => {
+    // A server that accepts the connection but never responds forces the
+    // AbortController timeout path — distinct from a refused connection.
+    const srv = net.createServer(() => {
+      /* accept, then hang: never write a response */
+    });
+    try {
+      const port: number = await new Promise((resolve) =>
+        srv.listen(0, '127.0.0.1', () => resolve((srv.address() as net.AddressInfo).port)),
+      );
+      const o = obsidivm({ baseUrl: `http://127.0.0.1:${port}`, timeoutMs: 200 });
+      const err = (await o.getSpec().then(() => null, (e: unknown) => e)) as (Error & { unreachable?: boolean }) | null;
+
+      expect(err, 'getSpec should reject on timeout').toBeTruthy();
+      expect(err!.message).toMatch(/timed out after \d+ms/i);
+      expect(err!.unreachable).toBeUndefined(); // a timeout is not "service down"
+    } finally {
+      // Fire-and-forget: the aborted request leaves a half-open socket, so
+      // awaiting close() would hang. Destroy connections and close without
+      // waiting — the assertions are already done. (closeAllConnections lands in
+      // newer @types/node than this repo pins, hence the cast.)
+      (srv as net.Server & { closeAllConnections?: () => void }).closeAllConnections?.();
+      srv.close();
+    }
+  });
+
+  it('reports a malformed base URL as a config error, not "unreachable"', async () => {
+    // ERR_INVALID_URL is the operator's mistake, not a down service — the message
+    // must point at OBSIDIVM_URL, not at starting the range service.
+    const o = obsidivm({ baseUrl: 'not-a-valid-url' });
+    const err = (await o.getSpec().then(() => null, (e: unknown) => e)) as (Error & { unreachable?: boolean }) | null;
+
+    expect(err, 'getSpec should reject on a bad URL').toBeTruthy();
+    expect(err!.message).toMatch(/invalid OBSIDIVM base URL/i);
+    expect(err!.message).toMatch(/OBSIDIVM_URL/);
+    expect(err!.message).not.toMatch(/unreachable|is it running/i);
+    expect(err!.unreachable).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #156.

## What was happening

`npm run obsidivm:bench:*` / `obsidivm:evolve` died with a bare **`FATAL: fetch failed`** — no mention of the OBSIDIVM service, the URL, or how to start it. The `obsidivm:*` benchmarks are a thin HTTP client over the separate OBSIDIVM range service (`docs/OBSIDIVM.md`, default `http://127.0.0.1:4200`); `obsidivm-bench.mjs` fetches the target spec via the bridge before anything prints, so with the service down the raw `fetch` throws straight through. `--hunter stub` hits it too — "stub" only means "no LLM hunter"; the grading step still needs the service, which the help text didn't say.

(The deterministic benches — `binary`/`mobile`/`cve`/`cloud` — pass offline and were never affected; "all benchmarks error" in the report was the OBSIDIVM ones plus, for the `evolve --hunter live` command, a missing LLM key.)

## The fix

Wrap the `fetch` in the bridge's shared `call()` — the single choke point for **every** OBSIDIVM request (`getSpec`/`scoreText`/`createRun`/…), so one guard fixes them all — and classify the failure:

| Failure | Before | After |
|---|---|---|
| service down (ECONNREFUSED) | `fetch failed` | `OBSIDIVM service unreachable at <url> … Start it per docs/OBSIDIVM.md (python3 range.py, :4200), or set OBSIDIVM_URL` + `err.unreachable` |
| request timeout (AbortError) | `fetch failed` | `OBSIDIVM <m> <path> timed out after <n>ms (<url>)` |
| malformed `OBSIDIVM_URL` (ERR_INVALID_URL) | `fetch failed` | `Invalid OBSIDIVM base URL "<v>" — set OBSIDIVM_URL … to a full URL like http://127.0.0.1:4200` |

The HTTP-status path (`!res.ok`) and body parsing are untouched — the new `catch` wraps only the `fetch()` call, so it never swallows a status or JSON error. Also clarified the bench `--help`/usage that **all** hunter modes (stub included) need the OBSIDIVM service, and live/t3mp3st additionally a key.

## Tests

RED-first (`70a4d5d` fails on `main` with the bare `fetch failed`). Three hermetic cases in `src/__tests__/obsidivm-bridge.test.ts`, no mocking:
- **unreachable**: bind an ephemeral port, close it, connect → ECONNREFUSED → asserts the actionable message names the URL + escape hatches and sets `err.unreachable`.
- **timeout**: a TCP server that accepts but never responds + short `timeoutMs` → asserts `timed out after Nms` and **not** `unreachable`.
- **invalid URL**: asserts the config-error message points at `OBSIDIVM_URL`, not at starting a service.

Adds `scripts/obsidivm-bridge.d.mts` so the test types cleanly (matches the sibling `.d.mts` stubs for the other benches).

The invalid-URL branch, the timeout coverage, and the completed type stub all came from an adversarial self-review of the first cut, which had folded ERR_INVALID_URL into the "unreachable — is it running?" message.

## Verification (macOS, Apple Silicon)

- `npm test`: **758 vitest** green (+2 new branch tests) + ops-preflight 11/11, model-matrix, refusal-frontier 19/19.
- `npm run typecheck`: clean. `eslint` on the changed TS test: clean. Timeout test is stable across repeated runs (~300 ms, no hang). (The `.mjs` files carry a pre-existing node-globals `no-undef` lint, identical on `main` and outside CI's `eslint src/**/*.ts` scope.)
- Live: `OBSIDIVM_URL=not-a-valid-url npm run obsidivm:bench:stub` and a stopped service now print the actionable messages above instead of `fetch failed`.

macOS-only verification, but the change is provider/OS-neutral error handling.
