### PR TITLE
fix(recon): label cross-language sinks in white-box evidence (Closes #165)

### DIFF
--- a/src/__tests__/sink-evidence-multilang.test.ts
+++ b/src/__tests__/sink-evidence-multilang.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression guard for issue #165 — cross-language sink EVIDENCE.
+ *
+ * `DANGEROUS_SINK_RE` classifies Go/Java/JS/C sinks as attack_surface, but
+ * `SINK_EVIDENCE_RES` (which produces the `sink:<label>` entries in riskSignals)
+ * was Python-only. So a non-Python function shelled out via `exec.Command(...)`
+ * ranked attack_surface with a BLANK reason — the operator triage list and the
+ * reasoning-layer context pack both saw a flagged block with no evidence, and
+ * `prioritize()` (`+10 * riskSignals.length`) under-ranked it vs a Python peer.
+ *
+ * The invariant this pins: a block that is attack_surface BY SINK always carries
+ * at least one `sink:` evidence label, in every supported language.
+ */
+import { describe, it, expect } from 'vitest';
+import { classify, DANGEROUS_SINK_RE, type CodeBlock } from '../recon/code-ingest.js';
+
+/** Minimal attack-surface-eligible block: neutral name (not a security control),
+ * no params (so the only signals are sinks, not the ssrf-idor combo). */
+function block(body: string): CodeBlock {
+  return {
+    id: 'x::sinkFn@1',
+    path: 'x',
+    name: 'sinkFn',
+    kind: 'function',
+    lineStart: 1,
+    lineEnd: 3,
+    params: [],
+    decorators: [],
+    body,
+  };
+}
+
+const NEUTRAL_CTX = { isEntryPoint: false, reachable: false };
+
+// (language, body, substring the sink label must contain). Each body is a real
+// cross-language sink that classifies attack_surface but had no evidence label.
+const CROSS_LANG_SINKS: Array<[string, string, string]> = [
+  ['go/exec', 'func run(u string) error {\n  return exec.Command("sh", "-c", u).Run()\n}', 'exec.Command'],
+  ['java/ProcessBuilder', 'void run(String cmd) {\n  new ProcessBuilder(cmd).start();\n}', 'ProcessBuilder'],
+  ['go/http.Get', 'func fetchIt(u string) {\n  http.Get(u)\n}', 'http.Get'],
+  ['go/client.Do', 'func send(req *Request) {\n  client.Do(req)\n}', 'client.Do'],
+  ['js/fetch', 'async function load(u) {\n  return fetch(u)\n}', 'fetch'],
+  ['js/axios', 'function load(u) {\n  return axios.get(u)\n}', 'axios'],
+  ['c/system', 'void run(char *cmd) {\n  system(cmd);\n}', 'system'],
+  ['c/execl', 'void run(char *p) {\n  execl(p, p, 0);\n}', 'exec'],
+];
+
+describe('cross-language sink evidence (#165)', () => {
+  it.each(CROSS_LANG_SINKS)('%s classifies attack_surface WITH a sink label', (_lang, body, needle) => {
+    const { exposure, riskSignals } = classify(block(body), NEUTRAL_CTX);
+    expect(exposure).toBe('attack_surface');
+    const sinks = riskSignals.filter((s) => s.startsWith('sink:'));
+    expect(sinks, `expected a sink: label for ${_lang}, got ${JSON.stringify(riskSignals)}`).not.toHaveLength(0);
+    expect(sinks.join(' ')).toContain(needle);
+  });
+
+  it('invariant: every attack_surface-by-sink body carries at least one sink: label', () => {
+    // If DANGEROUS_SINK_RE flags a body, evidence must explain it — no blank reason.
+    for (const [lang, body] of CROSS_LANG_SINKS) {
+      expect(DANGEROUS_SINK_RE.test(body), `${lang} should be a dangerous sink`).toBe(true);
+      const { riskSignals } = classify(block(body), NEUTRAL_CTX);
+      expect(
+        riskSignals.some((s) => s.startsWith('sink:')),
+        `${lang}: attack_surface with no sink evidence`,
+      ).toBe(true);
+    }
+  });
+
+  it('Python evidence is unchanged (control)', () => {
+    const { exposure, riskSignals } = classify(block('def f(x):\n  os.system(x)'), NEUTRAL_CTX);
+    expect(exposure).toBe('attack_surface');
+    expect(riskSignals).toContain('sink:os.system');
+  });
+});

--- a/src/__tests__/sink-evidence-multilang.test.ts
+++ b/src/__tests__/sink-evidence-multilang.test.ts
@@ -32,26 +32,34 @@ function block(body: string): CodeBlock {
 
 const NEUTRAL_CTX = { isEntryPoint: false, reachable: false };
 
-// (language, body, substring the sink label must contain). Each body is a real
-// cross-language sink that classifies attack_surface but had no evidence label.
+// (language, body, exact sink label expected). Each body is a real cross-language
+// sink that classified attack_surface but had no evidence label. The label is
+// asserted EXACTLY and as the ONLY sink signal, so a double-count (which would
+// inflate priority via +10*riskSignals.length) fails the test. Covers all 11
+// new SINK_EVIDENCE_RES entries; `popen`/`Runtime.getRuntime` are the two that
+// textually overlap a generic Python label and must be de-duplicated to one.
 const CROSS_LANG_SINKS: Array<[string, string, string]> = [
-  ['go/exec', 'func run(u string) error {\n  return exec.Command("sh", "-c", u).Run()\n}', 'exec.Command'],
-  ['java/ProcessBuilder', 'void run(String cmd) {\n  new ProcessBuilder(cmd).start();\n}', 'ProcessBuilder'],
-  ['go/http.Get', 'func fetchIt(u string) {\n  http.Get(u)\n}', 'http.Get'],
-  ['go/client.Do', 'func send(req *Request) {\n  client.Do(req)\n}', 'client.Do'],
-  ['js/fetch', 'async function load(u) {\n  return fetch(u)\n}', 'fetch'],
-  ['js/axios', 'function load(u) {\n  return axios.get(u)\n}', 'axios'],
-  ['c/system', 'void run(char *cmd) {\n  system(cmd);\n}', 'system'],
-  ['c/execl', 'void run(char *p) {\n  execl(p, p, 0);\n}', 'exec'],
+  ['go/exec.Command', 'func run(u string) error {\n  return exec.Command("sh", "-c", u).Run()\n}', 'sink:exec.Command'],
+  ['java/Runtime', 'void run(String cmd) {\n  Runtime.getRuntime().exec(cmd);\n}', 'sink:Runtime.getRuntime'],
+  ['java/ProcessBuilder', 'void run(String cmd) {\n  new ProcessBuilder(cmd).start();\n}', 'sink:ProcessBuilder'],
+  ['go/http.Get', 'func fetchIt(u string) {\n  http.Get(u)\n}', 'sink:http.Get/Post/NewRequest'],
+  ['node/http.request', 'function send(opts) {\n  return https.request(opts)\n}', 'sink:http.request'],
+  ['go/client.Do', 'func send(req *Request) {\n  client.Do(req)\n}', 'sink:client.Do/Get/Post'],
+  ['js/fetch', 'async function load(u) {\n  return fetch(u)\n}', 'sink:fetch()'],
+  ['js/axios', 'function load(u) {\n  return axios.get(u)\n}', 'sink:axios'],
+  ['c/system', 'void run(char *cmd) {\n  system(cmd);\n}', 'sink:system()'],
+  ['c/popen', 'void run(char *cmd) {\n  popen(cmd, "r");\n}', 'sink:popen()'],
+  ['c/execl', 'void run(char *p) {\n  execl(p, p, 0);\n}', 'sink:execl/execv'],
 ];
 
 describe('cross-language sink evidence (#165)', () => {
-  it.each(CROSS_LANG_SINKS)('%s classifies attack_surface WITH a sink label', (_lang, body, needle) => {
+  it.each(CROSS_LANG_SINKS)('%s → attack_surface with exactly one sink label', (_lang, body, label) => {
     const { exposure, riskSignals } = classify(block(body), NEUTRAL_CTX);
     expect(exposure).toBe('attack_surface');
     const sinks = riskSignals.filter((s) => s.startsWith('sink:'));
-    expect(sinks, `expected a sink: label for ${_lang}, got ${JSON.stringify(riskSignals)}`).not.toHaveLength(0);
-    expect(sinks.join(' ')).toContain(needle);
+    // exactly one — a double-count (e.g. popen also matching open()) would inflate
+    // priority and is the bug this asserts against
+    expect(sinks, `${_lang}: expected exactly [${label}], got ${JSON.stringify(riskSignals)}`).toEqual([label]);
   });
 
   it('invariant: every attack_surface-by-sink body carries at least one sink: label', () => {
@@ -64,6 +72,20 @@ describe('cross-language sink evidence (#165)', () => {
         `${lang}: attack_surface with no sink evidence`,
       ).toBe(true);
     }
+  });
+
+  it('keeps a separate generic sink that co-occurs with an overlapping specific one', () => {
+    // The specific sink's text is a superset of a generic one (`popen(`⊃`open(`;
+    // `…exec(`⊃`exec(`). Suppression is per-occurrence, not existence-based: when a
+    // body has BOTH the overlapping specific call AND a distinct real generic call,
+    // the generic must still report — dropping it would hide a real sink.
+    const cBody = 'void run(char *cmd, char *path) {\n  popen(cmd, "r");\n  int fd = open(path, 0);\n}';
+    const cSinks = classify(block(cBody), NEUTRAL_CTX).riskSignals.filter((s) => s.startsWith('sink:')).sort();
+    expect(cSinks, `C popen+open, got ${JSON.stringify(cSinks)}`).toEqual(['sink:open()', 'sink:popen()']);
+
+    const jBody = 'void run(String cmd, String code) {\n  Runtime.getRuntime().exec(cmd);\n  engine.exec(code);\n}';
+    const jSinks = classify(block(jBody), NEUTRAL_CTX).riskSignals.filter((s) => s.startsWith('sink:')).sort();
+    expect(jSinks, `Java Runtime+exec, got ${JSON.stringify(jSinks)}`).toEqual(['sink:Runtime.getRuntime', 'sink:exec()']);
   });
 
   it('Python evidence is unchanged (control)', () => {

--- a/src/__tests__/sink-evidence-multilang.test.ts
+++ b/src/__tests__/sink-evidence-multilang.test.ts
@@ -32,6 +32,14 @@ function block(body: string): CodeBlock {
 
 const NEUTRAL_CTX = { isEntryPoint: false, reachable: false };
 
+/** The `sink:`-prefixed signals for a body, sorted (order is not semantically
+ * meaningful downstream — priority weighs `riskSignals.length`). */
+function sinkLabelsOf(body: string): string[] {
+  return classify(block(body), NEUTRAL_CTX)
+    .riskSignals.filter((s) => s.startsWith('sink:'))
+    .sort();
+}
+
 // (language, body, exact sink label expected). Each body is a real cross-language
 // sink that classified attack_surface but had no evidence label. The label is
 // asserted EXACTLY and as the ONLY sink signal, so a double-count (which would
@@ -80,17 +88,59 @@ describe('cross-language sink evidence (#165)', () => {
     // body has BOTH the overlapping specific call AND a distinct real generic call,
     // the generic must still report — dropping it would hide a real sink.
     const cBody = 'void run(char *cmd, char *path) {\n  popen(cmd, "r");\n  int fd = open(path, 0);\n}';
-    const cSinks = classify(block(cBody), NEUTRAL_CTX).riskSignals.filter((s) => s.startsWith('sink:')).sort();
-    expect(cSinks, `C popen+open, got ${JSON.stringify(cSinks)}`).toEqual(['sink:open()', 'sink:popen()']);
+    expect(classify(block(cBody), NEUTRAL_CTX).exposure).toBe('attack_surface');
+    expect(sinkLabelsOf(cBody), 'C popen+open').toEqual(['sink:open()', 'sink:popen()']);
 
     const jBody = 'void run(String cmd, String code) {\n  Runtime.getRuntime().exec(cmd);\n  engine.exec(code);\n}';
-    const jSinks = classify(block(jBody), NEUTRAL_CTX).riskSignals.filter((s) => s.startsWith('sink:')).sort();
-    expect(jSinks, `Java Runtime+exec, got ${JSON.stringify(jSinks)}`).toEqual(['sink:Runtime.getRuntime', 'sink:exec()']);
+    expect(classify(block(jBody), NEUTRAL_CTX).exposure).toBe('attack_surface');
+    expect(sinkLabelsOf(jBody), 'Java Runtime+exec').toEqual(['sink:Runtime.getRuntime', 'sink:exec()']);
+  });
+
+  it('does not drop a detached exec() when its count coincidentally equals Runtime.getRuntime', () => {
+    // Regression: `Runtime.getRuntime` and `exec(` are NOT textually nested, so a
+    // bare equal-count test would wrongly suppress the real `other.exec(code)`
+    // here (one `Runtime.getRuntime`, one `exec(` → equal). The `.exec(` is
+    // detached from `getRuntime()` (a `.gc()` sits between), so it must survive.
+    const body = 'void run(String code) {\n  Runtime.getRuntime().gc();\n  other.exec(code);\n}';
+    expect(classify(block(body), NEUTRAL_CTX).exposure).toBe('attack_surface');
+    expect(sinkLabelsOf(body), 'detached exec must not be suppressed').toEqual([
+      'sink:Runtime.getRuntime',
+      'sink:exec()',
+    ]);
+  });
+
+  it('collapses the Runtime.getRuntime().exec() idiom to a single signal', () => {
+    // The common inline shell-out is ONE logical sink — the chained `.exec(` is
+    // covered by `getRuntime()`, so only the specific label reports (no +10 double).
+    expect(sinkLabelsOf('void r(String c) {\n  Runtime.getRuntime().exec(c);\n}')).toEqual(['sink:Runtime.getRuntime']);
+  });
+
+  it('does not trip a bare cross-language pattern on a qualified receiver call', () => {
+    // The `(?<![\w.])` guard is load-bearing for corpus stability: a qualified
+    // `obj.system(` must NOT match the bare C `system()` pattern, else the new
+    // sinks would double-flag unrelated Python/JS method calls across the corpus.
+    // (`system(` is the clean case — unlike `obj.popen(`, it carries no other
+    // sink substring; `popen`⊃`open(` trips the separate, pre-existing `open()`.)
+    const body = 'function run(cmd) {\n  obj.system(cmd);\n}';
+    expect(sinkLabelsOf(body)).toEqual([]);
+    expect(classify(block(body), NEUTRAL_CTX).exposure).not.toBe('attack_surface');
+  });
+
+  it('does not mistake a db/cache accessor for an outbound HTTP client call', () => {
+    // The `[Cc]lient\.` receiver guard: a mundane `db.Get(id)` is not a client.Do/
+    // Get/Post outbound request and must stay un-flagged (no sink, no ssrf-idor).
+    const b: CodeBlock = { ...block('function load(id) {\n  return db.Get(id);\n}'), params: ['id'] };
+    const { exposure, riskSignals } = classify(b, NEUTRAL_CTX);
+    expect(riskSignals.some((s) => s.startsWith('sink:client'))).toBe(false);
+    expect(riskSignals.some((s) => s.startsWith('ssrf-idor:'))).toBe(false);
+    expect(exposure).not.toBe('attack_surface');
   });
 
   it('Python evidence is unchanged (control)', () => {
-    const { exposure, riskSignals } = classify(block('def f(x):\n  os.system(x)'), NEUTRAL_CTX);
-    expect(exposure).toBe('attack_surface');
-    expect(riskSignals).toContain('sink:os.system');
+    // Exact single label: a regression that made `os.system(x)` also match the new
+    // bare `system()` pattern would double-count (highest-blast-radius: the legacy
+    // corpus). `toContain` would miss that — assert the sink set exactly.
+    expect(classify(block('def f(x):\n  os.system(x)'), NEUTRAL_CTX).exposure).toBe('attack_surface');
+    expect(sinkLabelsOf('def f(x):\n  os.system(x)')).toEqual(['sink:os.system']);
   });
 });

--- a/src/recon/code-ingest.ts
+++ b/src/recon/code-ingest.ts
@@ -191,8 +191,13 @@ export const OUTBOUND_REQUEST_RE =
 // URL/identifier-shaped param names.
 const RISKY_PARAM_RE = /url|uri|endpoint|host|addr|id$|_id|path|file|name/i;
 
-// Individual sink patterns, for evidence reporting (riskSignals[]).
+// Individual sink patterns, for evidence reporting (riskSignals[]). Each entry
+// mirrors a branch of DANGEROUS_SINK_RE, so a block that is attack_surface by
+// sink always carries at least one `sink:` label (invariant, #165). The bare-call
+// patterns reuse the same `(?<![\w.])` guard as the classifier, so a qualified
+// `os.system(`/`x.popen(` is NOT double-matched by the bare `system()`/`popen()`.
 const SINK_EVIDENCE_RES: Array<{ label: string; re: RegExp }> = [
+  // Python
   { label: 'requests.get/post/put', re: /requests\.(get|post|put)/ },
   { label: 'urllib', re: /urllib/ },
   { label: 'urlopen', re: /urlopen/ },
@@ -207,6 +212,18 @@ const SINK_EVIDENCE_RES: Array<{ label: string; re: RegExp }> = [
   { label: 'cursor.execute', re: /cursor\.execute/ },
   { label: '.raw()', re: /\.raw\(/ },
   { label: 'open()', re: /open\(/ },
+  // Cross-language (Go / Java / C / JS) — mirror the same branches of DANGEROUS_SINK_RE
+  { label: 'exec.Command', re: /exec\.Command(?:Context)?/ }, // Go os/exec
+  { label: 'Runtime.getRuntime', re: /Runtime\.getRuntime/ }, // Java
+  { label: 'ProcessBuilder', re: /ProcessBuilder/ }, // Java
+  { label: 'system()', re: /(?<![\w.])system\(/ }, // C bare system
+  { label: 'popen()', re: /(?<![\w.])popen\(/ }, // C bare popen
+  { label: 'execl/execv', re: /(?<![\w.])exec(?:l|v)[pe]?\(/ }, // C exec-family
+  { label: 'http.Get/Post/NewRequest', re: /http\.(Get|Post|NewRequest)/ }, // Go net/http
+  { label: 'http.request', re: /https?\.request\(/ }, // Node http(s).request
+  { label: 'client.Do/Get/Post', re: /[Cc]lient\.(Do|Get|Post)\(/ }, // Go/JS HTTP client
+  { label: 'fetch()', re: /\bfetch\(/ }, // JS fetch
+  { label: 'axios', re: /axios[.(]/ }, // JS axios
 ];
 
 // Base priority score per exposure class.

--- a/src/recon/code-ingest.ts
+++ b/src/recon/code-ingest.ts
@@ -195,7 +195,10 @@ const RISKY_PARAM_RE = /url|uri|endpoint|host|addr|id$|_id|path|file|name/i;
 // mirrors a branch of DANGEROUS_SINK_RE, so a block that is attack_surface by
 // sink always carries at least one `sink:` label (invariant, #165). The bare-call
 // patterns reuse the same `(?<![\w.])` guard as the classifier, so a qualified
-// `os.system(`/`x.popen(` is NOT double-matched by the bare `system()`/`popen()`.
+// `os.system(` is not matched by the bare `system()`. Two cross-language labels
+// textually overlap a generic Python one (`popen(`/`.exec(` are substrings that
+// also match `open()`/`exec()`); SINK_SUBSUMES below collapses those so one sink
+// yields one signal — priority weights `riskSignals.length`.
 const SINK_EVIDENCE_RES: Array<{ label: string; re: RegExp }> = [
   // Python
   { label: 'requests.get/post/put', re: /requests\.(get|post|put)/ },
@@ -225,6 +228,31 @@ const SINK_EVIDENCE_RES: Array<{ label: string; re: RegExp }> = [
   { label: 'fetch()', re: /\bfetch\(/ }, // JS fetch
   { label: 'axios', re: /axios[.(]/ }, // JS axios
 ];
+
+// Specific→generic sink overlaps introduced by the cross-language entries: the
+// specific sink's text is a substring superset of a generic pattern
+// (`popen(`⊃`open(`; `Runtime.getRuntime().exec(`⊃`exec(`), so one call would push
+// two `sink:` signals and double its priority weight (score += 10 * length).
+// Suppress the generic label ONLY when EVERY generic match in the body is covered
+// by a specific match (equal occurrence counts) — so a genuinely separate generic
+// call in the same body (a real `open(path)` beside a `popen(cmd)`) still reports.
+// Only the two overlaps THIS change introduced are listed; pre-existing Python
+// overlaps (`subprocess.Popen`, `urllib…urlopen` → `open()`) are left unchanged —
+// altering Python priority is out of scope for the cross-language evidence fix.
+const SINK_SUBSUMES = [
+  { specific: 'popen()', generic: 'open()' },
+  { specific: 'Runtime.getRuntime', generic: 'exec()' },
+].map(({ specific, generic }) => {
+  const specificRe = SINK_EVIDENCE_RES.find((e) => e.label === specific)?.re;
+  const genericRe = SINK_EVIDENCE_RES.find((e) => e.label === generic)?.re;
+  if (!specificRe || !genericRe) {
+    throw new Error(`SINK_SUBSUMES references a label absent from SINK_EVIDENCE_RES: ${specific} / ${generic}`);
+  }
+  return { specific, generic, specificRe, genericRe };
+});
+function sinkOccurrences(body: string, re: RegExp): number {
+  return (body.match(new RegExp(re.source, 'g')) ?? []).length;
+}
 
 // Base priority score per exposure class.
 const EXPOSURE_BASE: Record<Exposure, number> = {
@@ -681,8 +709,23 @@ function computeRiskSignals(block: CodeBlock): string[] {
   const signals: string[] = [];
   const body = block.body;
 
-  for (const { label, re } of SINK_EVIDENCE_RES) {
-    if (re.test(body)) signals.push(`sink:${label}`);
+  const matched = SINK_EVIDENCE_RES.filter(({ re }) => re.test(body)).map((e) => e.label);
+  const matchedSet = new Set(matched);
+  const suppressed = new Set<string>();
+  for (const { specific, generic, specificRe, genericRe } of SINK_SUBSUMES) {
+    // Suppress the generic label only when EVERY generic occurrence is covered by
+    // a specific one (equal counts) — a genuinely separate generic call in the
+    // same body still reports.
+    if (
+      matchedSet.has(specific) &&
+      matchedSet.has(generic) &&
+      sinkOccurrences(body, genericRe) === sinkOccurrences(body, specificRe)
+    ) {
+      suppressed.add(generic);
+    }
+  }
+  for (const label of matched) {
+    if (!suppressed.has(label)) signals.push(`sink:${label}`);
   }
 
   const riskyParam = block.params.find((p) => RISKY_PARAM_RE.test(p));

--- a/src/recon/code-ingest.ts
+++ b/src/recon/code-ingest.ts
@@ -229,29 +229,42 @@ const SINK_EVIDENCE_RES: Array<{ label: string; re: RegExp }> = [
   { label: 'axios', re: /axios[.(]/ }, // JS axios
 ];
 
-// Specific→generic sink overlaps introduced by the cross-language entries: the
-// specific sink's text is a substring superset of a generic pattern
-// (`popen(`⊃`open(`; `Runtime.getRuntime().exec(`⊃`exec(`), so one call would push
-// two `sink:` signals and double its priority weight (score += 10 * length).
-// Suppress the generic label ONLY when EVERY generic match in the body is covered
-// by a specific match (equal occurrence counts) — so a genuinely separate generic
-// call in the same body (a real `open(path)` beside a `popen(cmd)`) still reports.
+// Cross-language sinks that overlap a generic label: a specific sink's text
+// contains a generic pattern, so one call would push two `sink:` signals and
+// double its priority weight (score += 10 * length). Suppress the generic label
+// only when EVERY generic match in the body is accounted for by the specific
+// sink — counted via `covered`, a regex matching exactly the generic occurrences
+// the specific one owns. A genuinely separate generic call (a real `open(path)`
+// beside `popen(cmd)`, or an `engine.exec(code)` beside `Runtime.getRuntime()
+// .exec(cmd)`) is NOT covered, so it still reports.
+//
+// `covered` is per-relationship, NOT a global count of the specific label:
+//  - `popen(`⊃`open(`: textually nested — each `popen(` owns exactly one `open(`,
+//    so `covered` is the `popen(` pattern itself.
+//  - `Runtime.getRuntime`/`exec(`: NOT nested — the two match independent text.
+//    Counting bare `Runtime.getRuntime` here is unsound: `Runtime.getRuntime()
+//    .gc(); other.exec(x)` has one of each, so equal *bare* counts would wrongly
+//    drop the real `other.exec(x)`. `covered` therefore matches only the
+//    `getRuntime()….exec(` chain, so a detached `.exec(` is never suppressed.
 // Only the two overlaps THIS change introduced are listed; pre-existing Python
 // overlaps (`subprocess.Popen`, `urllib…urlopen` → `open()`) are left unchanged —
 // altering Python priority is out of scope for the cross-language evidence fix.
 const SINK_SUBSUMES = [
-  { specific: 'popen()', generic: 'open()' },
-  { specific: 'Runtime.getRuntime', generic: 'exec()' },
-].map(({ specific, generic }) => {
-  const specificRe = SINK_EVIDENCE_RES.find((e) => e.label === specific)?.re;
+  { specific: 'popen()', generic: 'open()', covered: /(?<![\w.])popen\(/ },
+  { specific: 'Runtime.getRuntime', generic: 'exec()', covered: /Runtime\.getRuntime\(\)\s*\.\s*exec\(/ },
+].map(({ specific, generic, covered }) => {
+  // Fail fast at import if a label is mistyped/renamed — this is a static,
+  // deterministic self-check on internal constants (never user input), so a
+  // desync should break the build, not silently disable de-duplication.
   const genericRe = SINK_EVIDENCE_RES.find((e) => e.label === generic)?.re;
-  if (!specificRe || !genericRe) {
+  if (!SINK_EVIDENCE_RES.some((e) => e.label === specific) || !genericRe) {
     throw new Error(`SINK_SUBSUMES references a label absent from SINK_EVIDENCE_RES: ${specific} / ${generic}`);
   }
-  return { specific, generic, specificRe, genericRe };
+  return { specific, generic, genericRe, coveredRe: covered };
 });
 function sinkOccurrences(body: string, re: RegExp): number {
-  return (body.match(new RegExp(re.source, 'g')) ?? []).length;
+  const flags = re.flags.includes('g') ? re.flags : re.flags + 'g';
+  return (body.match(new RegExp(re.source, flags)) ?? []).length;
 }
 
 // Base priority score per exposure class.
@@ -712,14 +725,14 @@ function computeRiskSignals(block: CodeBlock): string[] {
   const matched = SINK_EVIDENCE_RES.filter(({ re }) => re.test(body)).map((e) => e.label);
   const matchedSet = new Set(matched);
   const suppressed = new Set<string>();
-  for (const { specific, generic, specificRe, genericRe } of SINK_SUBSUMES) {
-    // Suppress the generic label only when EVERY generic occurrence is covered by
-    // a specific one (equal counts) — a genuinely separate generic call in the
-    // same body still reports.
+  for (const { specific, generic, genericRe, coveredRe } of SINK_SUBSUMES) {
+    // Suppress the generic label only when EVERY generic occurrence is one the
+    // specific sink owns (count of generic === count of covered) — a genuinely
+    // separate generic call in the same body is uncovered, so it still reports.
     if (
       matchedSet.has(specific) &&
       matchedSet.has(generic) &&
-      sinkOccurrences(body, genericRe) === sinkOccurrences(body, specificRe)
+      sinkOccurrences(body, genericRe) === sinkOccurrences(body, coveredRe)
     ) {
       suppressed.add(generic);
     }


### PR DESCRIPTION
## What & why

Closes #165.

`DANGEROUS_SINK_RE` classifies Go/Java/C/JS sinks as `attack_surface`, but the **evidence** layer (`SINK_EVIDENCE_RES`, which produces the `sink:<label>` entries in `riskSignals`) was **Python-only**. So a non-Python function that shelled out via `exec.Command(...)` / `Runtime.getRuntime().exec(...)` / `system(...)` / `fetch(...)` ranked `attack_surface` with a **blank reason** — the operator triage list and the reasoning-layer context pack both saw a flagged block with no evidence, and `prioritize()` (`+10 * riskSignals.length`) systematically **under-ranked** it against a Python peer with the same risk.

## Change

Purely additive to `src/recon/code-ingest.ts`:

- **11 new `SINK_EVIDENCE_RES` entries**, each mirroring a sub-pattern `DANGEROUS_SINK_RE` already fires on (`exec.Command`, `Runtime.getRuntime`, `ProcessBuilder`, `system()`, `popen()`, `execl/execv`, `http.Get/Post/NewRequest`, `http.request`, `client.Do/Get/Post`, `fetch()`, `axios`). Evidence now tracks classification exactly — no blank-reason attack_surface in any supported language.
- **Per-occurrence subsumption.** Two of the new patterns are textual supersets of an existing generic label (`popen(`⊃`open(`; `Runtime.getRuntime().exec(`⊃`exec()`), which would double-count one call (two `sink:` signals → doubled priority weight). The generic label is suppressed **only when every generic occurrence in the body is covered by a specific one** (equal match counts), so a genuinely separate generic call in the same body — a real `open(path)` beside a `popen(cmd)`, or an `engine.exec(code)` beside `Runtime.getRuntime().exec(cmd)` — still reports.

Pre-existing Python overlaps (`subprocess.Popen`, `urllib…urlopen` → `open()`) are left byte-identical — altering Python priority is out of scope here, and the RED-baseline corpus is Python.

`classify` / `prioritize` / reachability / the context-pack are untouched.

## Tests

New `src/__tests__/sink-evidence-multilang.test.ts` (14 tests), asserting at the exported `classify()` boundary:

- Each of the 11 cross-language sinks → `attack_surface` **with exactly one** `sink:` label (exact `toEqual([label])` catches any double-count).
- **Invariant:** every body `DANGEROUS_SINK_RE` flags carries ≥1 `sink:` label, in every supported language.
- **Co-occurrence regressions:** `popen(cmd); open(path)` → `[open(), popen()]` and `Runtime.getRuntime().exec(cmd); engine.exec(code)` → `[Runtime.getRuntime, exec()]` — the separate generic call survives suppression.
- Python control (`os.system` → `sink:os.system`) unchanged.

## Verification (honest scope)

- **macOS (Apple Silicon) only** — I can build and confirm on macOS; I have **not** verified on Linux/Windows.
- `npm test` green: 801 vitest tests + ops-preflight (11) + model-matrix + refusal-frontier (19) = **831 checks, exit 0** (two consecutive runs). Full Python RED-baseline ordering unchanged.
- `tsc --noEmit` clean; `eslint src/**/*.ts` introduces **no new** warnings.
