### PR TITLE
fix: refresh live operator profiles at task boundaries

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26990,14 +26990,26 @@ Be specific and actionable. Format as structured JSON.`;
     try { const d = await (await fetch(base()+'/api/operators/prompt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({archetype:SELECTED,systemPrompt:ed.systemPrompt,params:ed.params})})).json();
       if(d.error) throw new Error(d.error);
       if(d.operator){ const i=ROSTER.findIndex(x=>x.archetype===SELECTED); if(i>=0) ROSTER[i]=d.operator; }
-      renderRoster(); renderEditor(); if(window.toast) toast('💾 '+SELECTED+' updated — applies to every spawned operator','success');
+      renderRoster(); renderEditor();
+      if(window.toast){
+        const applied=(d.application&&d.application.appliedOperatorIds||[]).length;
+        const deferred=(d.application&&d.application.deferredOperatorIds||[]).length;
+        const detail=deferred ? deferred+' active deferred until next task · '+applied+' idle updated now' : applied ? applied+' idle operator(s) updated now' : 'applies to future spawns';
+        toast('💾 '+SELECTED+' updated — '+detail,'success');
+      }
     } catch(e){ if(window.toast) toast('Save failed: '+e.message,'error'); }
   };
   window.resetOperative = async function(){
     try { const d = await (await fetch(base()+'/api/operators/prompt/reset',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({archetype:SELECTED})})).json();
       if(d.error) throw new Error(d.error);
       if(d.operator){ const i=ROSTER.findIndex(x=>x.archetype===SELECTED); if(i>=0) ROSTER[i]=d.operator; }
-      ADVICE=null; renderRoster(); renderEditor(); if(window.toast) toast('↺ '+SELECTED+' reset to default','info');
+      ADVICE=null; renderRoster(); renderEditor();
+      if(window.toast){
+        const applied=(d.application&&d.application.appliedOperatorIds||[]).length;
+        const deferred=(d.application&&d.application.deferredOperatorIds||[]).length;
+        const detail=deferred ? deferred+' active deferred until next task · '+applied+' idle reset now' : applied ? applied+' idle operator(s) reset now' : 'applies to future spawns';
+        toast('↺ '+SELECTED+' reset — '+detail,'info');
+      }
     } catch(e){ if(window.toast) toast('Reset failed: '+e.message,'error'); }
   };
 

--- a/src/__tests__/operator-profile-refresh.test.ts
+++ b/src/__tests__/operator-profile-refresh.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AgentLoop, AgentResult } from '../agent/index.js';
+import {
+  OperatorCell,
+  resetOperatorOverride,
+  setOperatorOverride,
+} from '../operators/index.js';
+
+const task = {
+  id: 'profile-refresh-task',
+  missionId: 'profile-refresh-mission',
+  name: 'Profile refresh boundary',
+  description: 'Exercise the operator profile refresh boundary.',
+  phase: 'reconnaissance' as const,
+  operatorType: 'recon' as const,
+  status: 'pending' as const,
+  priority: 1,
+  dependencies: [],
+  createdAt: Date.now(),
+};
+
+const result: AgentResult = {
+  success: true,
+  summary: 'done',
+  steps: [],
+  findings: [],
+  iterations: 1,
+  tokensUsed: 0,
+  durationMs: 1,
+  hitLimit: false,
+};
+
+afterEach(() => {
+  resetOperatorOverride('recon');
+});
+
+describe('live operator profile refresh', () => {
+  it('updates idle matching operators immediately and future spawns inherit the revision', () => {
+    resetOperatorOverride('recon');
+    const cell = new OperatorCell();
+    const existing = cell.spawnOperator('Existing Recon', 'recon');
+
+    setOperatorOverride('recon', { systemPrompt: 'REVISED-RECON-PROFILE' });
+    const application = cell.refreshOperatorProfiles('recon');
+    const future = cell.spawnOperator('Future Recon', 'recon');
+
+    expect(application).toMatchObject({
+      policy: 'idle-now-active-next-task',
+      appliedOperatorIds: [existing.id],
+      deferredOperatorIds: [],
+      futureSpawns: true,
+    });
+    expect(existing.profile.systemPrompt).toBe('REVISED-RECON-PROFILE');
+    expect(future.profile.systemPrompt).toBe('REVISED-RECON-PROFILE');
+    expect(existing.getSummary()).toMatchObject({
+      profileRevision: application.revision,
+      pendingProfileRevision: null,
+    });
+  });
+
+  it('defers an executing operator until the task boundary without changing its in-flight profile', async () => {
+    resetOperatorOverride('recon');
+    const cell = new OperatorCell();
+    const operator = cell.spawnOperator('Busy Recon', 'recon', { cooldownMs: 0 }, {} as never);
+    const originalPrompt = operator.profile.systemPrompt;
+
+    let finishRun!: (value: AgentResult) => void;
+    const runningLoop = {
+      on: () => runningLoop,
+      off: () => runningLoop,
+      run: () => new Promise<AgentResult>(resolve => { finishRun = resolve; }),
+    } as unknown as AgentLoop;
+    operator.attachArsenal({} as never, runningLoop);
+
+    const execution = operator.assignTask(task as never);
+    await Promise.resolve();
+    expect(operator.status).toBe('executing');
+
+    setOperatorOverride('recon', { systemPrompt: 'NEXT-TASK-RECON-PROFILE' });
+    const application = cell.refreshOperatorProfiles('recon');
+
+    expect(application.appliedOperatorIds).toEqual([]);
+    expect(application.deferredOperatorIds).toEqual([operator.id]);
+    expect(operator.profile.systemPrompt).toBe(originalPrompt);
+    expect(operator.getSummary().pendingProfileRevision).toBe(application.revision);
+
+    finishRun(result);
+    await execution;
+
+    expect(operator.status).toBe('idle');
+    expect(operator.profile.systemPrompt).toBe('NEXT-TASK-RECON-PROFILE');
+    expect(operator.getSummary()).toMatchObject({
+      profileRevision: application.revision,
+      pendingProfileRevision: null,
+    });
+  });
+
+  it('applies reset through the same immediate/deferred contract', () => {
+    setOperatorOverride('recon', { systemPrompt: 'CUSTOM-RECON-PROFILE' });
+    const cell = new OperatorCell();
+    const operator = cell.spawnOperator('Reset Recon', 'recon');
+
+    resetOperatorOverride('recon');
+    const application = cell.refreshOperatorProfiles('recon');
+
+    expect(application.appliedOperatorIds).toEqual([operator.id]);
+    expect(operator.profile.systemPrompt).not.toBe('CUSTOM-RECON-PROFILE');
+    expect(operator.getSummary().profileRevision).toBe(application.revision);
+  });
+});

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -171,6 +171,17 @@ export interface OperatorParams { temperature: number; maxTokens: number; topP: 
 export interface OperatorOverride { systemPrompt?: string; params?: Partial<OperatorParams>; }
 const DEFAULT_OPERATOR_PARAMS: OperatorParams = { temperature: 0.4, maxTokens: 4096, topP: 1.0 };
 const OPERATOR_OVERRIDES: Partial<Record<OperatorArchetype, OperatorOverride>> = {};
+const OPERATOR_PROFILE_REVISIONS: Partial<Record<OperatorArchetype, number>> = {};
+
+function advanceOperatorProfileRevision(archetype: OperatorArchetype): number {
+  const revision = (OPERATOR_PROFILE_REVISIONS[archetype] || 0) + 1;
+  OPERATOR_PROFILE_REVISIONS[archetype] = revision;
+  return revision;
+}
+
+export function getOperatorProfileRevision(archetype: OperatorArchetype): number {
+  return OPERATOR_PROFILE_REVISIONS[archetype] || 0;
+}
 
 export function setOperatorOverride(archetype: OperatorArchetype, override: OperatorOverride): void {
   const cur = OPERATOR_OVERRIDES[archetype] || {};
@@ -178,8 +189,12 @@ export function setOperatorOverride(archetype: OperatorArchetype, override: Oper
     systemPrompt: override.systemPrompt !== undefined ? override.systemPrompt : cur.systemPrompt,
     params: { ...(cur.params || {}), ...(override.params || {}) },
   };
+  advanceOperatorProfileRevision(archetype);
 }
-export function resetOperatorOverride(archetype: OperatorArchetype): void { delete OPERATOR_OVERRIDES[archetype]; }
+export function resetOperatorOverride(archetype: OperatorArchetype): void {
+  delete OPERATOR_OVERRIDES[archetype];
+  advanceOperatorProfileRevision(archetype);
+}
 export function getOperatorParams(archetype: OperatorArchetype): OperatorParams {
   return { ...DEFAULT_OPERATOR_PARAMS, ...(OPERATOR_OVERRIDES[archetype]?.params || {}) };
 }
@@ -205,6 +220,7 @@ export function listOperatorPrompts() {
       systemPrompt: (ov && ov.systemPrompt) || base.systemPrompt,
       defaultSystemPrompt: base.systemPrompt,
       params: getOperatorParams(a),
+      revision: getOperatorProfileRevision(a),
       overridden: !!(ov && (ov.systemPrompt || (ov.params && Object.keys(ov.params).length))),
     };
   });
@@ -269,7 +285,7 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
   public readonly id: string;
   public readonly callsign: string;
   public readonly archetype: OperatorArchetype;
-  public readonly profile: ArchetypeProfile;
+  public profile: ArchetypeProfile;
   public readonly config: OperatorConfig;
 
   private _state: OperatorState;
@@ -282,6 +298,8 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
   private credentials: Credential[] = [];
   /** White-box source excerpt (security-prioritized), set by TempestCommand.setWhiteboxSource */
   private whiteboxSource: string = '';
+  private profileRevision: number;
+  private pendingProfileRevision: number | null = null;
 
   constructor(
     callsign: string,
@@ -294,6 +312,7 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
     this.callsign = callsign;
     this.archetype = archetype;
     this.profile = resolveProfile(archetype);
+    this.profileRevision = getOperatorProfileRevision(archetype);
     this.config = { ...DEFAULT_OPERATOR_CONFIG, ...config };
     this.llm = llm;
 
@@ -341,6 +360,7 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
    * Assign a task to the operator
    */
   async assignTask(task: Task, target?: Target): Promise<TaskResult> {
+    this.applyPendingProfileRefresh();
     if (!this.isAvailable()) {
       throw new Error(`Operator ${this.callsign} is not available (status: ${this._state.status})`);
     }
@@ -404,6 +424,30 @@ export class OperatorAgent extends EventEmitter<OperatorEvents> {
         error: errorMessage,
       };
     }
+  }
+
+  /**
+   * Adopt the latest archetype profile without changing an in-flight request.
+   * Idle operators update immediately; all other live states defer until the
+   * next transition back to idle.
+   */
+  requestProfileRefresh(): 'applied' | 'deferred' {
+    const latestRevision = getOperatorProfileRevision(this.archetype);
+    if (this._state.status === 'idle') {
+      this.profile = resolveProfile(this.archetype);
+      this.profileRevision = latestRevision;
+      this.pendingProfileRevision = null;
+      return 'applied';
+    }
+    this.pendingProfileRevision = latestRevision;
+    return 'deferred';
+  }
+
+  private applyPendingProfileRefresh(): void {
+    if (this.pendingProfileRevision === null || this._state.status !== 'idle') return;
+    this.profile = resolveProfile(this.archetype);
+    this.profileRevision = getOperatorProfileRevision(this.archetype);
+    this.pendingProfileRevision = null;
   }
 
   /**
@@ -771,6 +815,7 @@ Respond in a structured format.`;
   private setStatus(newStatus: OperatorStatus): void {
     const oldStatus = this._state.status;
     this._state.status = newStatus;
+    if (newStatus === 'idle') this.applyPendingProfileRefresh();
     this.emit('status:changed', { oldStatus, newStatus });
   }
 
@@ -803,6 +848,8 @@ Respond in a structured format.`;
     findings: number;
     credentials: number;
     detectionRisk: number;
+    profileRevision: number;
+    pendingProfileRevision: number | null;
   } {
     return {
       id: this.id,
@@ -814,6 +861,8 @@ Respond in a structured format.`;
       findings: this._state.findingsCount,
       credentials: this._state.credentialsCount,
       detectionRisk: this._state.detectionRisk,
+      profileRevision: this.profileRevision,
+      pendingProfileRevision: this.pendingProfileRevision,
     };
   }
 }
@@ -929,6 +978,28 @@ export class OperatorCell extends EventEmitter<CellEvents> {
    */
   getOperatorsByArchetype(archetype: OperatorArchetype): OperatorAgent[] {
     return this.getAllOperators().filter(op => op.archetype === archetype);
+  }
+
+  refreshOperatorProfiles(archetype: OperatorArchetype): {
+    policy: 'idle-now-active-next-task';
+    revision: number;
+    appliedOperatorIds: string[];
+    deferredOperatorIds: string[];
+    futureSpawns: true;
+  } {
+    const appliedOperatorIds: string[] = [];
+    const deferredOperatorIds: string[] = [];
+    for (const operator of this.getOperatorsByArchetype(archetype)) {
+      const result = operator.requestProfileRefresh();
+      (result === 'applied' ? appliedOperatorIds : deferredOperatorIds).push(operator.id);
+    }
+    return {
+      policy: 'idle-now-active-next-task',
+      revision: getOperatorProfileRevision(archetype),
+      appliedOperatorIds,
+      deferredOperatorIds,
+      futureSpawns: true,
+    };
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -6586,9 +6586,16 @@ app.post('/api/operators/prompt', (req: Request, res: Response): void => {
     return;
   }
   setOperatorOverride(archetype as OperatorArchetype, override);
-  broadcastEvent('operator:prompt_updated', { archetype, hasPrompt: override.systemPrompt !== undefined, hasParams: !!override.params });
+  const application = getTempestCommand()?.cell.refreshOperatorProfiles(archetype as OperatorArchetype) || {
+    policy: 'idle-now-active-next-task' as const,
+    revision: listOperatorPrompts().find(o => o.archetype === archetype)?.revision || 0,
+    appliedOperatorIds: [],
+    deferredOperatorIds: [],
+    futureSpawns: true as const,
+  };
+  broadcastEvent('operator:prompt_updated', { archetype, hasPrompt: override.systemPrompt !== undefined, hasParams: !!override.params, application });
   const updated = listOperatorPrompts().find(o => o.archetype === archetype);
-  res.json({ ok: true, archetype, operator: updated });
+  res.json({ ok: true, archetype, operator: updated, application });
 });
 
 app.post('/api/operators/prompt/reset', (req: Request, res: Response): void => {
@@ -6598,9 +6605,16 @@ app.post('/api/operators/prompt/reset', (req: Request, res: Response): void => {
     return;
   }
   resetOperatorOverride(archetype as OperatorArchetype);
-  broadcastEvent('operator:prompt_updated', { archetype, reset: true });
+  const application = getTempestCommand()?.cell.refreshOperatorProfiles(archetype as OperatorArchetype) || {
+    policy: 'idle-now-active-next-task' as const,
+    revision: listOperatorPrompts().find(o => o.archetype === archetype)?.revision || 0,
+    appliedOperatorIds: [],
+    deferredOperatorIds: [],
+    futureSpawns: true as const,
+  };
+  broadcastEvent('operator:prompt_updated', { archetype, reset: true, application });
   const updated = listOperatorPrompts().find(o => o.archetype === archetype);
-  res.json({ ok: true, archetype, operator: updated });
+  res.json({ ok: true, archetype, operator: updated, application });
 });
 
 app.post('/api/operators/spawn', (req: Request, res: Response): void => {


### PR DESCRIPTION
## Summary

- version per-archetype operative configuration revisions
- apply revisions immediately to idle matching instances
- defer revisions for busy instances until they return to the task boundary
- return applied/deferred IDs in save/reset responses and update events
- make Operatives feedback accurately describe live versus future application
- cover immediate, deferred, reset, and future-spawn behavior

## Linked issue

Closes #167

## Contribution receipt

- Scope class: static_fixture
- Target authority: local repository behavior only
- Network use: none
- Claims or evidence changed: none
- Redaction/provenance notes: update events contain revision metadata and operative IDs, never edited configuration text

## Verification

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run doctor`
- [x] Risk-specific checks are listed below

Exact commands and results:

- `npm run test:pr` — passed; 70 test files / 790 tests, doctor 0 blockers
- `COVERAGE_BASE=upstream/main PR_CHANGED_LINE_COVERAGE=50 npm run test:pr-coverage` — passed; changed-line coverage gate 100% (required 50%)
- Focused operator-profile and UI parse suite — 2 files / 6 tests passed

## Risk and rollback

- Residual risk: clients that ignore the additive `application` response field are unaffected; profile revision counters are process-local, matching the existing override lifecycle
- Rollback: revert commit `e5a702c`

## Delivery checks

- [x] Diff is scoped against current `upstream/main`
- [x] No unrelated protected evidence, safety tests, or provider/config files were removed
- [x] Published review history was not force-pushed
- [ ] Exact-head PR CI is green (including the 50% changed-line coverage floor)
- [x] I understand PR acceptance is not release certification