### PR TITLE
feat: add provenance-safe threat feed ingestion

### DIFF
--- a/src/__tests__/fixtures/cisa-kev.json
+++ b/src/__tests__/fixtures/cisa-kev.json
@@ -1,0 +1,11 @@
+{
+  "title": "CISA Known Exploited Vulnerabilities Catalog",
+  "catalogVersion": "2026.09.01",
+  "dateReleased": "2026-09-01T10:00:00.000Z",
+  "count": 3,
+  "vulnerabilities": [
+    {"cveID":"CVE-2024-0001","vendorProject":"Example","product":"Widget","vulnerabilityName":"Example flaw","dateAdded":"2026-08-01","shortDescription":"fixture","requiredAction":"Apply updates","dueDate":"2026-08-22","knownRansomwareCampaignUse":"Unknown","notes":""},
+    {"cveID":"cve-2024-0001","vendorProject":"Duplicate","product":"Duplicate","vulnerabilityName":"Duplicate","dateAdded":"2026-08-01","shortDescription":"fixture","requiredAction":"Apply updates","dueDate":"2026-08-22","knownRansomwareCampaignUse":"Unknown","notes":""},
+    {"cveID":"CVE-2025-12345","vendorProject":"Acme","product":"Anvil","vulnerabilityName":"Anvil flaw","dateAdded":"2026-08-02","shortDescription":"fixture","requiredAction":"Remove product","dueDate":"2026-08-23","knownRansomwareCampaignUse":"Known","notes":""}
+  ]
+}

--- a/src/__tests__/fixtures/first-epss.json
+++ b/src/__tests__/fixtures/first-epss.json
@@ -1,0 +1,14 @@
+{
+  "status": "OK",
+  "status-code": 200,
+  "version": "1.0",
+  "access": "public",
+  "total": 3,
+  "offset": 0,
+  "limit": 100,
+  "data": [
+    {"cve":"CVE-2024-0001","epss":"0.125","percentile":"0.75","date":"2026-09-01"},
+    {"cve":"cve-2024-0001","epss":"0.999","percentile":"0.999","date":"2026-09-01"},
+    {"cve":"CVE-2025-12345","epss":"0.5","percentile":"0.9","date":"2026-09-01"}
+  ]
+}

--- a/src/__tests__/threat-feed.test.ts
+++ b/src/__tests__/threat-feed.test.ts
@@ -1,0 +1,117 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryFeedCache,
+  ThreatFeedClient,
+  normalizeEpss,
+  normalizeKev,
+  type CachedFeed,
+  type KevRecord,
+} from '../threat-intel/feed.js';
+
+const fixture = async (name: string): Promise<unknown> =>
+  JSON.parse(await readFile(new URL(`./fixtures/${name}`, import.meta.url), 'utf8')) as unknown;
+const response = (body: unknown, init?: ResponseInit): Response => new Response(JSON.stringify(body), init);
+
+describe('threat intelligence feed ingestion', () => {
+  it('normalizes, deduplicates, and retains CISA provenance', async () => {
+    const feed = normalizeKev(await fixture('cisa-kev.json'), 'https://cisa.example/kev.json', '2026-09-03T00:00:00.000Z');
+    expect(feed.records).toHaveLength(2);
+    expect(feed.records[0]?.cveId).toBe('CVE-2024-0001');
+    expect(feed.provenance).toEqual({
+      source: 'cisa-kev', sourceUrl: 'https://cisa.example/kev.json', retrievedAt: '2026-09-03T00:00:00.000Z',
+      schemaVersion: '2026.09.01', upstreamPublishedAt: '2026-09-01T10:00:00.000Z',
+      upstreamRecordCount: 3,
+    });
+    expect(feed.records[0]?.provenance).toBe(feed.provenance);
+  });
+
+  it('normalizes numeric EPSS probabilities and deduplicates CVEs', async () => {
+    const feed = normalizeEpss(await fixture('first-epss.json'), 'https://first.example/epss', '2026-09-03T00:00:00.000Z');
+    expect(feed.records).toHaveLength(2);
+    expect(feed.records[0]).toMatchObject({ cveId: 'CVE-2024-0001', score: 0.125, percentile: 0.75 });
+    expect(feed.provenance.schemaVersion).toBe('1.0');
+    expect(feed.provenance).toMatchObject({ upstreamRecordCount: 3, pageOffset: 0, pageLimit: 100 });
+  });
+
+  it('refreshes both sources independently and writes the cache', async () => {
+    const kev = await fixture('cisa-kev.json');
+    const epss = await fixture('first-epss.json');
+    const client = new ThreatFeedClient({
+      fetch: async (url) => response(String(url).includes('cisa') ? kev : epss),
+      now: () => new Date('2026-09-03T00:00:00.000Z'),
+    });
+    const result = await client.refresh();
+    expect(result.errors).toEqual({});
+    expect(result.kev).toMatchObject({ state: 'fresh', stale: false });
+    expect(result.epss).toMatchObject({ state: 'fresh', stale: false });
+  });
+
+  it('returns a stale cached source while preserving a successful source', async () => {
+    const cache = new MemoryFeedCache();
+    const old = normalizeKev(await fixture('cisa-kev.json'), 'https://old.example/kev', '2026-08-01T00:00:00.000Z');
+    await cache.set('cisa-kev', old);
+    const epss = await fixture('first-epss.json');
+    const client = new ThreatFeedClient({
+      cache,
+      fetch: async (url) => {
+        if (String(url).includes('cisa')) throw new Error('offline');
+        return response(epss);
+      },
+      now: () => new Date('2026-09-03T00:00:00.000Z'),
+      maxCacheAgeMs: 86_400_000,
+    });
+    const result = await client.refresh();
+    expect(result.kev).toMatchObject({ state: 'cached', stale: true });
+    expect(result.epss).toMatchObject({ state: 'fresh', stale: false });
+    expect(result.errors['cisa-kev']).toBe('offline');
+  });
+
+  it('reports a missing failed source without discarding the other source', async () => {
+    const epss = await fixture('first-epss.json');
+    const client = new ThreatFeedClient({ fetch: async (url) => String(url).includes('cisa') ? response({}, { status: 503 }) : response(epss) });
+    const result = await client.refresh();
+    expect(result.kev).toBeUndefined();
+    expect(result.epss?.records).toHaveLength(2);
+    expect(result.errors['cisa-kev']).toContain('HTTP 503');
+  });
+
+  it('rejects malformed schemas and out-of-range scores', () => {
+    expect(() => normalizeKev({ catalogVersion: '1', vulnerabilities: {} }, 'u', '2026-01-01T00:00:00Z')).toThrow('array');
+    expect(() => normalizeEpss({ version: '1', data: [{ cve: 'CVE-2024-0001', epss: '2', percentile: '0.5', date: '2026-01-01' }] }, 'u', '2026-01-01T00:00:00Z')).toThrow('probability');
+  });
+
+  it('reports malformed JSON without replacing it with invented records', async () => {
+    const client = new ThreatFeedClient({ fetch: async () => new Response('{not-json') });
+    const result = await client.refresh();
+    expect(result.kev).toBeUndefined();
+    expect(result.epss).toBeUndefined();
+    expect(result.errors['cisa-kev']).toContain('malformed JSON');
+    expect(result.errors['first-epss']).toContain('malformed JSON');
+  });
+
+  it('bounds declared and streamed response sizes', async () => {
+    const declared = new ThreatFeedClient({ fetch: async () => new Response('{}', { headers: { 'content-length': '999' } }), maxResponseBytes: 10 });
+    expect((await declared.refresh()).errors['cisa-kev']).toContain('size limit');
+    const streamed = new ThreatFeedClient({ fetch: async () => response({ version: '1', data: [] }), maxResponseBytes: 4 });
+    expect((await streamed.refresh()).errors['first-epss']).toContain('size limit');
+  });
+
+  it('aborts requests that exceed the configured timeout', async () => {
+    const hangingFetch = (_url: string | URL | Request, init?: RequestInit): Promise<Response> => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error('timed out')));
+    });
+    const result = await new ThreatFeedClient({ fetch: hangingFetch, timeoutMs: 5 }).refresh();
+    expect(result.errors['cisa-kev']).toBe('timed out');
+    expect(result.errors['first-epss']).toBe('timed out');
+  });
+
+  it('marks an invalid cache timestamp stale', async () => {
+    const cache = new MemoryFeedCache();
+    const value = normalizeKev(await fixture('cisa-kev.json'), 'u', '2026-09-03T00:00:00.000Z') as CachedFeed<KevRecord>;
+    value.cachedAt = 'invalid';
+    await cache.set('cisa-kev', value);
+    const result = await new ThreatFeedClient({ cache, fetch: async () => { throw new Error('offline'); } }).refresh();
+    expect(result.kev?.stale).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1641,3 +1641,5 @@ export function getBanner(): string {
 
 // Default export
 export default createTempest;
+
+export * from './threat-intel/feed.js';

--- a/src/threat-intel/feed.ts
+++ b/src/threat-intel/feed.ts
@@ -1,0 +1,253 @@
+export const CISA_KEV_URL =
+  'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+export const FIRST_EPSS_URL = 'https://api.first.org/data/v1/epss';
+
+export type FeedSource = 'cisa-kev' | 'first-epss';
+
+export interface FeedProvenance {
+  source: FeedSource;
+  sourceUrl: string;
+  retrievedAt: string;
+  schemaVersion: string;
+  upstreamPublishedAt?: string;
+  upstreamRecordCount?: number;
+  pageOffset?: number;
+  pageLimit?: number;
+}
+
+export interface KevRecord {
+  cveId: string;
+  vendor: string;
+  product: string;
+  vulnerabilityName: string;
+  dateAdded: string;
+  dueDate: string;
+  requiredAction: string;
+  knownRansomwareCampaignUse: string;
+  provenance: FeedProvenance;
+}
+
+export interface EpssRecord {
+  cveId: string;
+  score: number;
+  percentile: number;
+  scoreDate: string;
+  provenance: FeedProvenance;
+}
+
+export interface CachedFeed<T> {
+  provenance: FeedProvenance;
+  records: T[];
+  cachedAt: string;
+}
+
+export interface FeedCache {
+  get<T>(source: FeedSource): Promise<CachedFeed<T> | undefined>;
+  set<T>(source: FeedSource, value: CachedFeed<T>): Promise<void>;
+}
+
+export interface FeedResult<T> extends CachedFeed<T> {
+  state: 'fresh' | 'cached';
+  stale: boolean;
+}
+
+export interface ThreatFeedSnapshot {
+  kev?: FeedResult<KevRecord>;
+  epss?: FeedResult<EpssRecord>;
+  errors: Partial<Record<FeedSource, string>>;
+}
+
+export class MemoryFeedCache implements FeedCache {
+  private readonly values = new Map<FeedSource, CachedFeed<unknown>>();
+
+  async get<T>(source: FeedSource): Promise<CachedFeed<T> | undefined> {
+    return this.values.get(source) as CachedFeed<T> | undefined;
+  }
+
+  async set<T>(source: FeedSource, value: CachedFeed<T>): Promise<void> {
+    this.values.set(source, value as CachedFeed<unknown>);
+  }
+}
+
+export interface ThreatFeedClientOptions {
+  fetch?: typeof fetch;
+  cache?: FeedCache;
+  now?: () => Date;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+  maxCacheAgeMs?: number;
+  kevUrl?: string;
+  epssUrl?: string;
+}
+
+const CVE_ID = /^CVE-\d{4}-\d{4,}$/i;
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`${label} must be a non-empty string`);
+  return value.trim();
+}
+
+function probability(value: unknown, label: string): number {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  if (typeof parsed !== 'number' || !Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`${label} must be a probability`);
+  }
+  return parsed;
+}
+
+function optionalNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+export function normalizeKev(payload: unknown, sourceUrl: string, retrievedAt: string): CachedFeed<KevRecord> {
+  const root = object(payload, 'CISA KEV response');
+  if (!Array.isArray(root.vulnerabilities)) throw new Error('CISA KEV vulnerabilities must be an array');
+  const provenance: FeedProvenance = {
+    source: 'cisa-kev', sourceUrl, retrievedAt,
+    schemaVersion: string(root.catalogVersion, 'CISA KEV catalogVersion'),
+    ...(typeof root.dateReleased === 'string' ? { upstreamPublishedAt: root.dateReleased } : {}),
+    ...(optionalNonNegativeInteger(root.count) !== undefined ? { upstreamRecordCount: optionalNonNegativeInteger(root.count) } : {}),
+  };
+  const records = new Map<string, KevRecord>();
+  for (const raw of root.vulnerabilities) {
+    const item = object(raw, 'CISA KEV vulnerability');
+    const cveId = string(item.cveID, 'CISA KEV cveID').toUpperCase();
+    if (!CVE_ID.test(cveId)) throw new Error(`invalid CISA KEV cveID: ${cveId}`);
+    if (records.has(cveId)) continue;
+    records.set(cveId, {
+      cveId,
+      vendor: string(item.vendorProject, `${cveId} vendorProject`),
+      product: string(item.product, `${cveId} product`),
+      vulnerabilityName: string(item.vulnerabilityName, `${cveId} vulnerabilityName`),
+      dateAdded: string(item.dateAdded, `${cveId} dateAdded`),
+      dueDate: string(item.dueDate, `${cveId} dueDate`),
+      requiredAction: string(item.requiredAction, `${cveId} requiredAction`),
+      knownRansomwareCampaignUse: string(item.knownRansomwareCampaignUse, `${cveId} knownRansomwareCampaignUse`),
+      provenance,
+    });
+  }
+  return { provenance, records: [...records.values()], cachedAt: retrievedAt };
+}
+
+export function normalizeEpss(payload: unknown, sourceUrl: string, retrievedAt: string): CachedFeed<EpssRecord> {
+  const root = object(payload, 'FIRST EPSS response');
+  if (!Array.isArray(root.data)) throw new Error('FIRST EPSS data must be an array');
+  const provenance: FeedProvenance = {
+    source: 'first-epss', sourceUrl, retrievedAt,
+    schemaVersion: string(root.version, 'FIRST EPSS version'),
+    ...(optionalNonNegativeInteger(root.total) !== undefined ? { upstreamRecordCount: optionalNonNegativeInteger(root.total) } : {}),
+    ...(optionalNonNegativeInteger(root.offset) !== undefined ? { pageOffset: optionalNonNegativeInteger(root.offset) } : {}),
+    ...(optionalNonNegativeInteger(root.limit) !== undefined ? { pageLimit: optionalNonNegativeInteger(root.limit) } : {}),
+  };
+  const records = new Map<string, EpssRecord>();
+  for (const raw of root.data) {
+    const item = object(raw, 'FIRST EPSS record');
+    const cveId = string(item.cve, 'FIRST EPSS cve').toUpperCase();
+    if (!CVE_ID.test(cveId)) throw new Error(`invalid FIRST EPSS cve: ${cveId}`);
+    if (records.has(cveId)) continue;
+    records.set(cveId, {
+      cveId,
+      score: probability(item.epss, `${cveId} epss`),
+      percentile: probability(item.percentile, `${cveId} percentile`),
+      scoreDate: string(item.date, `${cveId} date`),
+      provenance,
+    });
+  }
+  return { provenance, records: [...records.values()], cachedAt: retrievedAt };
+}
+
+export class ThreatFeedClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly cache: FeedCache;
+  private readonly now: () => Date;
+  private readonly timeoutMs: number;
+  private readonly maxResponseBytes: number;
+  private readonly maxCacheAgeMs: number;
+  private readonly kevUrl: string;
+  private readonly epssUrl: string;
+
+  constructor(options: ThreatFeedClientOptions = {}) {
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.cache = options.cache ?? new MemoryFeedCache();
+    this.now = options.now ?? (() => new Date());
+    this.timeoutMs = options.timeoutMs ?? 20_000;
+    this.maxResponseBytes = options.maxResponseBytes ?? 16 * 1024 * 1024;
+    this.maxCacheAgeMs = options.maxCacheAgeMs ?? 24 * 60 * 60 * 1000;
+    this.kevUrl = options.kevUrl ?? CISA_KEV_URL;
+    this.epssUrl = options.epssUrl ?? FIRST_EPSS_URL;
+  }
+
+  async refresh(): Promise<ThreatFeedSnapshot> {
+    const [kev, epss] = await Promise.all([
+      this.refreshSource('cisa-kev', this.kevUrl, normalizeKev),
+      this.refreshSource('first-epss', this.epssUrl, normalizeEpss),
+    ]);
+    return {
+      ...(kev.feed ? { kev: kev.feed } : {}),
+      ...(epss.feed ? { epss: epss.feed } : {}),
+      errors: { ...(kev.error ? { 'cisa-kev': kev.error } : {}), ...(epss.error ? { 'first-epss': epss.error } : {}) },
+    };
+  }
+
+  private async refreshSource<T>(
+    source: FeedSource,
+    url: string,
+    normalize: (payload: unknown, sourceUrl: string, retrievedAt: string) => CachedFeed<T>,
+  ): Promise<{ feed?: FeedResult<T>; error?: string }> {
+    try {
+      const retrievedAt = this.now().toISOString();
+      const payload = await this.fetchJson(url);
+      const value = normalize(payload, url, retrievedAt);
+      await this.cache.set(source, value);
+      return { feed: { ...value, state: 'fresh', stale: false } };
+    } catch (error) {
+      const cached = await this.cache.get<T>(source);
+      const message = error instanceof Error ? error.message : String(error);
+      if (!cached) return { error: message };
+      const age = this.now().getTime() - Date.parse(cached.cachedAt);
+      return { feed: { ...cached, state: 'cached', stale: !Number.isFinite(age) || age > this.maxCacheAgeMs }, error: message };
+    }
+  }
+
+  private async fetchJson(url: string): Promise<unknown> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(url, {
+        signal: controller.signal,
+        headers: { accept: 'application/json', 'user-agent': 'T3MP3ST/1.0 threat-feed-ingestion' },
+      });
+      if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`);
+      const declared = Number(response.headers.get('content-length'));
+      if (Number.isFinite(declared) && declared > this.maxResponseBytes) throw new Error(`${url} response exceeds size limit`);
+      if (!response.body) throw new Error(`${url} returned an empty body`);
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let size = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (size > this.maxResponseBytes) {
+          await reader.cancel();
+          throw new Error(`${url} response exceeds size limit`);
+        }
+        chunks.push(value);
+      }
+      const bytes = new Uint8Array(size);
+      let offset = 0;
+      for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+      try { return JSON.parse(new TextDecoder().decode(bytes)) as unknown; }
+      catch { throw new Error(`${url} returned malformed JSON`); }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a focused, public threat-intelligence ingestion layer for CISA KEV and FIRST EPSS. It provides typed normalization, explicit source/schema/retrieval provenance, bounded HTTP reads, deterministic deduplication, independent source failures, and an injectable stale-cache fallback.

This intentionally excludes UI, scoring policy, CVE correlation, probes, mission automation, persistence providers, and embedded vulnerability claims.

## Linked issue

Closes #171

## Prior work and attribution

- Prior PR or issue used: notes/reference
- Reused/adapted areas: source selection and the high-level idea of a KEV/EPSS feed from #163; implementation and contracts were rewritten for this issue
- Fresh verification performed for reused material: strict runtime validation; deterministic fixtures; timeout, size, malformed-response, partial-failure, deduplication, refresh, and offline-cache tests

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163,
which informed this focused change.

## Contribution receipt

- Scope class: local_lab
- Target authority: public read-only CISA KEV and FIRST EPSS sources; tests use injected local responses only
- Network use: none during tests
- Claims or evidence changed: none
- Redaction/provenance notes: normalized records retain source URL, retrieval timestamp, upstream schema version, publication/page metadata when supplied, and source identity; no fixed catalog count is asserted as current

## Verification

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run doctor`
- [x] Risk-specific checks are listed below

Exact commands and results:

- `npx vitest run src/__tests__/threat-feed.test.ts` — 10/10 passed
- `npm run test:pr` — passed; 834 tests, doctor 0 blockers (5 documented optional-tool/API-offline warnings)
- `npm run verify-claims` — 27/27 claims verified
- `COVERAGE_BASE=upstream/main PR_CHANGED_LINE_COVERAGE=50 npm run test:pr-coverage` — 834 tests passed; 131/131 changed executable lines covered (100%)
- `npm run lint` — 0 errors; repository baseline warnings only

## Risk and rollback

- Residual risk: upstream providers can evolve their schemas; failures are explicit and independently fall back to marked cached data where available. The EPSS API's returned pagination metadata is retained rather than implying a complete global snapshot.
- Rollback: revert the squash commit; no migration or persistent state is introduced.

## Delivery checks

- [x] Diff is scoped against current `upstream/main`
- [x] No unrelated protected evidence, safety tests, or provider/config files were removed
- [x] Published review history was not force-pushed
- [x] Reused or adapted prior work is identified, re-verified, and credited
- [ ] Exact-head PR CI is green (including the 50% changed-line coverage floor)
- [x] I understand PR acceptance is not release certification
