### PR TITLE
feat: add provenance-safe CVE correlation API

### DIFF
--- a/docs/CVE_CORRELATION.md
+++ b/docs/CVE_CORRELATION.md
@@ -1,0 +1,19 @@
+# Technology-to-CVE correlation
+
+`POST /api/recon/correlate-cves` compares technology observations with a caller-supplied, already-ingested CISA KEV snapshot and optionally joins FIRST EPSS records by CVE ID. Correlation never performs a remote fetch.
+
+## Request and limits
+
+The JSON body contains `technologies` (1–100 `{ name, version?, source? }` observations), `kev` (a `FeedResult<KevRecord>`), and optional `epss` (a `FeedResult<EpssRecord>`). Each feed is limited to 10,000 records. The server validates feed metadata, record provenance, CVE identifiers, and EPSS probabilities; invalid bodies receive HTTP 400.
+
+## Match semantics
+
+- Exact normalized product or vendor-plus-product names have confidence `0.95`.
+- Multi-token subset matches have confidence `0.8`.
+- Known aliases have confidence `0.75`.
+- Broad single-token matches have confidence `0.45` and should be treated as discovery leads.
+- If either supplied feed is stale, every confidence value is capped at `0.5` and the response carries a warning.
+
+Versions are preserved but are not evaluated against affected-version ranges because KEV does not supply those ranges. Results therefore report `not-evaluated` (or `not-provided`) and always carry `verificationStatus: "unverified-candidate"`. A match must never be presented as a verified vulnerability finding without independent product/version validation.
+
+Every result embeds its original KEV record and any joined EPSS record, including their provenance. Duplicate CVEs are collapsed to the highest-confidence observation and output is deterministic. An empty KEV snapshot returns HTTP 200 with `status: "empty-feed"`, no matches, and the standard verification warning.

--- a/src/__tests__/cve-correlation.test.ts
+++ b/src/__tests__/cve-correlation.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { correlateTechnologies, handleCorrelationApi } from '../threat-intel/correlation.js';
+import type { EpssRecord, FeedProvenance, FeedResult, KevRecord } from '../threat-intel/feed.js';
+
+const kevProvenance: FeedProvenance = {
+  source: 'cisa-kev', sourceUrl: 'https://www.cisa.gov/kev.json', retrievedAt: '2026-09-01T00:00:00.000Z', schemaVersion: '2026.09.01',
+};
+const epssProvenance: FeedProvenance = {
+  source: 'first-epss', sourceUrl: 'https://api.first.org/epss', retrievedAt: '2026-09-01T00:00:00.000Z', schemaVersion: '1.0',
+};
+const kevRecord = (cveId: string, vendor: string, product: string): KevRecord => ({
+  cveId, vendor, product, vulnerabilityName: `${product} vulnerability`, dateAdded: '2026-08-01', dueDate: '2026-08-22',
+  requiredAction: 'Apply mitigations', knownRansomwareCampaignUse: 'Unknown', provenance: kevProvenance,
+});
+const feed = <T>(provenance: FeedProvenance, records: T[], stale = false): FeedResult<T> => ({
+  provenance, records, cachedAt: '2026-09-01T00:00:00.000Z', state: stale ? 'cached' : 'fresh', stale,
+});
+
+describe('technology-to-CVE correlation', () => {
+  it('returns provenance-preserving unverified candidates and joins EPSS by CVE', () => {
+    const kev = feed(kevProvenance, [kevRecord('CVE-2026-1234', 'F5', 'BIG-IP')]);
+    const epssRecord: EpssRecord = { cveId: 'CVE-2026-1234', score: 0.72, percentile: 0.94, scoreDate: '2026-09-01', provenance: epssProvenance };
+    const result = correlateTechnologies({ technologies: [{ name: 'F5 BIG-IP', version: '17.1', source: 'banner' }], kev, epss: feed(epssProvenance, [epssRecord]) });
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({ cveId: 'CVE-2026-1234', confidence: 0.95, matchBasis: 'exact-product', versionStatus: 'not-evaluated', verificationStatus: 'unverified-candidate', kev: kev.records[0], epss: epssRecord });
+    expect(result.source).toEqual({ kev: kevProvenance, epss: epssProvenance });
+  });
+
+  it('keeps broad matches low-confidence, rejects partial-word false positives, and sorts deterministically', () => {
+    const kev = feed(kevProvenance, [
+      kevRecord('CVE-2026-9999', 'Apache', 'HTTP Server'),
+      kevRecord('CVE-2026-1111', 'Apache', 'Tomcat'),
+      kevRecord('CVE-2026-2222', 'Acme', 'WordPress Connector'),
+    ]);
+    const result = correlateTechnologies({ technologies: [{ name: 'Apache' }, { name: 'press' }, { name: 'go' }], kev });
+
+    expect(result.matches.map(({ cveId }) => cveId)).toEqual(['CVE-2026-1111', 'CVE-2026-9999']);
+    expect(result.matches.every(({ confidence }) => confidence === 0.45)).toBe(true);
+    expect(result.matches.every(({ versionStatus }) => versionStatus === 'not-provided')).toBe(true);
+  });
+
+  it('deduplicates CVEs to the strongest observation and caps stale confidence', () => {
+    const record = kevRecord('CVE-2026-1234', 'F5', 'BIG-IP');
+    const result = correlateTechnologies({ technologies: [{ name: 'F5' }, { name: 'F5 BIG-IP' }], kev: feed(kevProvenance, [record], true) });
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({ confidence: 0.5, technology: { name: 'F5 BIG-IP' }, stale: true });
+    expect(result.warnings.join(' ')).toContain('stale');
+  });
+
+  it('reports an empty feed without upgrading it to an error or finding', () => {
+    const result = correlateTechnologies({ technologies: [{ name: 'nginx' }], kev: feed(kevProvenance, []) });
+    expect(result).toMatchObject({ status: 'empty-feed', matches: [] });
+    expect(result.warnings.join(' ')).toContain('unverified candidates');
+  });
+
+  it.each([
+    [undefined, 'request body'],
+    [{ technologies: [], kev: feed(kevProvenance, []) }, 'technologies'],
+    [{ technologies: [{ name: 'nginx' }], kev: { ...feed(kevProvenance, []), provenance: { ...kevProvenance, source: 'first-epss' } } }, 'cisa-kev'],
+    [{ technologies: [{ name: 'nginx' }], kev: feed(kevProvenance, [{}]) }, 'cveId'],
+  ])('returns HTTP 400 for malformed API input %#', (body, message) => {
+    const result = handleCorrelationApi(body);
+    expect(result.status).toBe(400);
+    expect(result.body).toHaveProperty('error', expect.stringContaining(message));
+  });
+
+  it('wires a fetch-free server route to the validated boundary handler', () => {
+    const source = readFileSync(new URL('../server.ts', import.meta.url), 'utf8');
+    const route = source.match(/app\.post\('\/api\/recon\/correlate-cves'[\s\S]*?\n}\);/)?.[0];
+    expect(route).toContain('handleCorrelationApi(req.body)');
+    expect(route).not.toMatch(/fetch|ThreatFeedClient/);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1643,4 +1643,5 @@ export function getBanner(): string {
 export default createTempest;
 
 export * from './threat-intel/feed.js';
+export * from './threat-intel/correlation.js';
 export * from './llm/context-compression.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -7687,6 +7687,17 @@ import {
   scaffoldAttackGraph, validateAttackGraph, attackGraphReconPrompt, familyPhases,
   ATTACK_GRAPH_SCHEMA, type AttackGraph,
 } from './recon/attack-graph.js';
+import { handleCorrelationApi } from './threat-intel/correlation.js';
+
+/**
+ * POST /api/recon/correlate-cves — correlate observed technology names with an
+ * already-ingested KEV snapshot and optional EPSS snapshot. This endpoint does
+ * not fetch remote data and returns candidates, never verified findings.
+ */
+app.post('/api/recon/correlate-cves', (req: Request, res: Response): void => {
+  const result = handleCorrelationApi(req.body);
+  res.status(result.status).json(result.body);
+});
 
 /**
  * POST /api/attack-graph — get an attack graph for a target.

--- a/src/threat-intel/correlation.ts
+++ b/src/threat-intel/correlation.ts
@@ -1,0 +1,124 @@
+import type { EpssRecord, FeedProvenance, FeedResult, FeedSource, KevRecord } from './feed.js';
+
+export interface TechnologyObservation { name: string; version?: string; source?: string }
+export interface CorrelationRequest { technologies: TechnologyObservation[]; kev: FeedResult<KevRecord>; epss?: FeedResult<EpssRecord> }
+export interface CorrelationMatch {
+  cveId: string; technology: TechnologyObservation; vendor: string; product: string; vulnerabilityName: string;
+  confidence: number; matchBasis: 'exact-product' | 'token-overlap' | 'alias';
+  versionStatus: 'not-provided' | 'not-evaluated'; verificationStatus: 'unverified-candidate';
+  kev: KevRecord; epss?: EpssRecord; stale: boolean;
+}
+export interface CorrelationResponse {
+  status: 'ok' | 'empty-feed'; matches: CorrelationMatch[]; warnings: string[];
+  source: { kev: FeedResult<KevRecord>['provenance']; epss?: FeedResult<EpssRecord>['provenance'] };
+}
+export interface CorrelationApiResult { status: 200 | 400; body: CorrelationResponse | { error: string } }
+
+const ALIASES: Readonly<Record<string, readonly string[]>> = {
+  nginx: ['nginx'], openssh: ['openssh', 'ssh'], 'apache http server': ['apache', 'http server'],
+  'microsoft exchange': ['microsoft', 'exchange'], 'citrix netscaler': ['citrix', 'netscaler'],
+  'palo alto pan os': ['palo alto', 'pan os'],
+};
+function normalized(value: string): string { return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' '); }
+function words(value: string): string[] { return normalized(value).split(' ').filter((word) => word.length >= 3); }
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+function text(value: unknown, label: string, max = 2_000): string {
+  if (typeof value !== 'string' || !value.trim() || value.length > max) throw new Error(`${label} must be a non-empty string of at most ${max} characters`);
+  return value;
+}
+function provenance(value: unknown, source: FeedSource, label: string): FeedProvenance {
+  const item = object(value, `${label}.provenance`);
+  if (item.source !== source) throw new Error(`${label}.provenance.source must be ${source}`);
+  text(item.sourceUrl, `${label}.provenance.sourceUrl`);
+  text(item.retrievedAt, `${label}.provenance.retrievedAt`, 100);
+  text(item.schemaVersion, `${label}.provenance.schemaVersion`, 100);
+  return item as unknown as FeedProvenance;
+}
+function feed(value: unknown, source: FeedSource, label: string): Record<string, unknown> {
+  const item = object(value, label);
+  if (!Array.isArray(item.records) || item.records.length > 10_000) throw new Error(`${label}.records must be an array with at most 10000 records`);
+  provenance(item.provenance, source, label);
+  text(item.cachedAt, `${label}.cachedAt`, 100);
+  if (item.state !== 'fresh' && item.state !== 'cached') throw new Error(`${label}.state must be fresh or cached`);
+  if (typeof item.stale !== 'boolean') throw new Error(`${label}.stale must be a boolean`);
+  return item;
+}
+function validateKev(value: unknown): FeedResult<KevRecord> {
+  const item = feed(value, 'cisa-kev', 'kev');
+  for (const [index, raw] of (item.records as unknown[]).entries()) {
+    const record = object(raw, `kev.records[${index}]`);
+    if (!/^CVE-\d{4}-\d{4,}$/i.test(text(record.cveId, `kev.records[${index}].cveId`, 40))) throw new Error(`kev.records[${index}].cveId must be a CVE identifier`);
+    for (const field of ['vendor', 'product', 'vulnerabilityName', 'dateAdded', 'dueDate', 'requiredAction', 'knownRansomwareCampaignUse'] as const) text(record[field], `kev.records[${index}].${field}`);
+    provenance(record.provenance, 'cisa-kev', `kev.records[${index}]`);
+  }
+  return item as unknown as FeedResult<KevRecord>;
+}
+function validateEpss(value: unknown): FeedResult<EpssRecord> {
+  const item = feed(value, 'first-epss', 'epss');
+  for (const [index, raw] of (item.records as unknown[]).entries()) {
+    const record = object(raw, `epss.records[${index}]`);
+    if (!/^CVE-\d{4}-\d{4,}$/i.test(text(record.cveId, `epss.records[${index}].cveId`, 40))) throw new Error(`epss.records[${index}].cveId must be a CVE identifier`);
+    for (const field of ['score', 'percentile'] as const) if (typeof record[field] !== 'number' || !Number.isFinite(record[field]) || record[field] < 0 || record[field] > 1) throw new Error(`epss.records[${index}].${field} must be a probability`);
+    text(record.scoreDate, `epss.records[${index}].scoreDate`, 100);
+    provenance(record.provenance, 'first-epss', `epss.records[${index}]`);
+  }
+  return item as unknown as FeedResult<EpssRecord>;
+}
+
+function validateRequest(value: unknown): CorrelationRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('request body must be an object');
+  const body = value as Partial<CorrelationRequest>;
+  if (!Array.isArray(body.technologies) || body.technologies.length === 0 || body.technologies.length > 100) throw new Error('technologies must contain 1 to 100 observations');
+  for (const [index, technology] of body.technologies.entries()) {
+    if (!technology || typeof technology.name !== 'string' || !normalized(technology.name) || technology.name.length > 200) throw new Error(`technologies[${index}].name must be a non-empty string of at most 200 characters`);
+    if (technology.version !== undefined && (typeof technology.version !== 'string' || technology.version.length > 100)) throw new Error(`technologies[${index}].version must be a string of at most 100 characters`);
+  }
+  return { technologies: body.technologies, kev: validateKev(body.kev), ...(body.epss ? { epss: validateEpss(body.epss) } : {}) };
+}
+
+function matchTechnology(technology: TechnologyObservation, record: KevRecord): Pick<CorrelationMatch, 'confidence' | 'matchBasis'> | undefined {
+  const needle = normalized(technology.name);
+  const product = normalized(record.product);
+  const vendorProduct = normalized(`${record.vendor} ${record.product}`);
+  if (needle === product || needle === vendorProduct) return { confidence: 0.95, matchBasis: 'exact-product' };
+  const needleWords = words(needle);
+  const recordWords = words(vendorProduct);
+  if (needleWords.length && needleWords.every((word) => recordWords.includes(word))) return { confidence: needleWords.length > 1 ? 0.8 : 0.45, matchBasis: 'token-overlap' };
+  const aliases = ALIASES[needle];
+  if (aliases?.some((alias) => vendorProduct.includes(alias))) return { confidence: 0.75, matchBasis: 'alias' };
+  return undefined;
+}
+
+export function correlateTechnologies(request: CorrelationRequest): CorrelationResponse {
+  const epss = new Map(request.epss?.records.map((record) => [record.cveId, record]));
+  const matches = new Map<string, CorrelationMatch>();
+  const stale = request.kev.stale || Boolean(request.epss?.stale);
+  for (const technology of request.technologies) {
+    for (const kev of request.kev.records) {
+      const match = matchTechnology(technology, kev);
+      if (!match) continue;
+      const candidate: CorrelationMatch = {
+        cveId: kev.cveId, technology: { ...technology }, vendor: kev.vendor, product: kev.product,
+        vulnerabilityName: kev.vulnerabilityName, confidence: stale ? Math.min(match.confidence, 0.5) : match.confidence,
+        matchBasis: match.matchBasis, versionStatus: technology.version ? 'not-evaluated' : 'not-provided',
+        verificationStatus: 'unverified-candidate', kev, ...(epss.get(kev.cveId) ? { epss: epss.get(kev.cveId) } : {}), stale,
+      };
+      const previous = matches.get(kev.cveId);
+      if (!previous || candidate.confidence > previous.confidence) matches.set(kev.cveId, candidate);
+    }
+  }
+  return {
+    status: request.kev.records.length ? 'ok' : 'empty-feed',
+    matches: [...matches.values()].sort((a, b) => b.confidence - a.confidence || a.cveId.localeCompare(b.cveId)),
+    warnings: ['Technology correlation identifies unverified candidates; it does not establish that an observed version is affected.', ...(stale ? ['One or more source feeds are stale; confidence is capped at 0.5.'] : [])],
+    source: { kev: request.kev.provenance, ...(request.epss ? { epss: request.epss.provenance } : {}) },
+  };
+}
+
+export function handleCorrelationApi(body: unknown): CorrelationApiResult {
+  try { return { status: 200, body: correlateTechnologies(validateRequest(body)) }; }
+  catch (error) { return { status: 400, body: { error: error instanceof Error ? error.message : 'invalid correlation request' } }; }
+}


### PR DESCRIPTION
Closes #172

## Summary

- add a pure, fetch-free technology-to-CVE correlation API over normalized KEV and optional EPSS snapshots
- preserve record provenance and classify every result as an unverified candidate
- validate bounded request/feed data at runtime and document confidence, version, false-positive, empty-feed, and stale-feed behavior
- add focused coverage for correlation logic, malformed requests, provenance, deterministic output, and server wiring

## Verification

- `npx vitest run src/__tests__/cve-correlation.test.ts` (9 tests)
- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` (77 files, 855 tests; changed-line gate passed)
- `npm run test:pr` (passed; 855 Vitest tests plus preflight/model/refusal checks and doctor)
- `npm run verify-claims` (27 passed, 0 failed)

## Evidence boundary

The endpoint consumes caller-supplied snapshots already normalized by the feed layer. It performs no network access, does not evaluate version ranges absent from KEV, and never upgrades a technology-name match into a verified finding.

Original feature proposal and decomposition input from @xxmafiaxxx in #163 and #164.
