### PR TITLE
feat: enforce tool-call repair and reflection boundaries

### DIFF
--- a/docs/TOOL_CALL_BOUNDARIES.md
+++ b/docs/TOOL_CALL_BOUNDARIES.md
@@ -1,0 +1,9 @@
+# Tool-call repair and reflection boundaries
+
+Text-model tool calls pass through `enforceToolCallBoundary` before reaching the agent loop. The boundary accepts only explicit JSON action-contract payloads, removes trailing commas as its sole syntax repair, and validates the call against the exact tool definitions offered for that request. It never guesses a tool name, argument, target, authorization value, or schema default.
+
+Malformed JSON, unknown tools, absent or invalid arguments, extra fields forbidden by a schema, and duplicate calls raise an observable `ToolCallBoundaryError`. Because this occurs inside the provider request, the existing bounded LLM retry policy handles retries and exposes retry events; exhaustion remains a hard error. Ordinary prose without a tool-call shape remains a valid final response.
+
+`reflectStrategy` is advisory only. Its output always sets `mayExecute: false`, copies the current scope, approval, receipt, evidence, iteration, and token boundaries, and marks proposed out-of-scope targets or unapproved tools as requiring approval. A caller must still submit any later action through the normal Arsenal scope, schema, approval, receipt, budget, and evidence gates.
+
+Model text and tool output are untrusted content. Neither repair nor reflection interprets instructions embedded in that content as authority.

--- a/src/__tests__/tool-call-boundary.test.ts
+++ b/src/__tests__/tool-call-boundary.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { enforceToolCallBoundary, reflectStrategy, ToolCallBoundaryError } from '../llm/tool-call-boundary.js';
+import type { LLMToolDefinition } from '../types/index.js';
+
+const tools: LLMToolDefinition[] = [{
+  name: 'http_probe', description: 'Probe an authorized URL',
+  parameters: {
+    type: 'object', required: ['url'],
+    properties: { url: { type: 'string' }, timeout: { type: 'number' } },
+  },
+}];
+
+describe('tool-call repair boundary', () => {
+  it('repairs only trailing commas and preserves supplied arguments', () => {
+    const result = enforceToolCallBoundary('```json\n{"tool_calls":[{"name":"http_probe","arguments":{"url":"https://lab",}},]}\n```', tools);
+    expect(result.calls).toEqual([{ id: expect.stringMatching(/^repaired_/), name: 'http_probe', arguments: { url: 'https://lab' } }]);
+  });
+
+  it('decodes a JSON-encoded argument object without filling missing fields', () => {
+    const result = enforceToolCallBoundary('{"tool_calls":[{"name":"http_probe","arguments":"{\\"url\\":\\"https://lab\\",}"}]}', tools);
+    expect(result.calls?.[0].arguments).toEqual({ url: 'https://lab' });
+  });
+
+  it('treats ordinary prose as a final response rather than an invalid call', () => {
+    expect(enforceToolCallBoundary('Testing is complete; no further action.', tools)).toEqual({ attempted: false });
+  });
+
+  it.each([
+    ['```json\n{"tool_calls":[}\n```', 'malformed JSON'],
+    ['{"tool_calls":[{"name":"shell","arguments":{}}]}', 'unknown tool'],
+    ['{"tool_calls":[{"name":"http_probe","arguments":{}}]}', 'url is required'],
+    ['{"tool_calls":[{"name":"http_probe","arguments":{"url":"https://lab","authorization":true}}]}', 'authorization is not allowed'],
+    ['{"tool_calls":[{"name":"http_probe","arguments":{"url":"https://lab"}},{"name":"http_probe","arguments":{"url":"https://lab"}}]}', 'duplicates'],
+    ['{"tool_calls":[{"name":"http_probe","arguments":{"url":"https://lab","timeout":"invent-me"}}]}', 'timeout must be a number'],
+  ])('fails closed with an observable error: %s', (input, message) => {
+    expect(() => enforceToolCallBoundary(input, tools)).toThrowError(expect.objectContaining({ name: 'ToolCallBoundaryError', message: expect.stringContaining(message) }));
+  });
+
+  it('rejects hostile oversized content before parsing', () => {
+    expect(() => enforceToolCallBoundary(`{"name":"http_probe"}${'x'.repeat(1_000_000)}`, tools)).toThrow(ToolCallBoundaryError);
+  });
+
+  it('is wired inside text adapters so boundary errors enter the bounded retry loop', () => {
+    const source = readFileSync(new URL('../llm/index.ts', import.meta.url), 'utf8');
+    expect(source.match(/enforceToolCallBoundary\([^;]+/g)?.length).toBe(3);
+    expect(source).toContain('for (let attempt = 1; attempt <= this.retryAttempts; attempt++)');
+    expect(source).toContain("this.emit('request:retry'");
+  });
+
+  it('is wired into anti-stall handling as an advisory event', () => {
+    const source = readFileSync(new URL('../agent/index.ts', import.meta.url), 'utf8');
+    expect(source).toContain("this.emit('agent:reflection'");
+    expect(source).toContain('all scope, approval, receipt, budget, and evidence gates still apply');
+  });
+});
+
+describe('strategic reflection boundary', () => {
+  it('can recommend a pivot but cannot execute or alter authority and evidence gates', () => {
+    const boundary = { scope: ['lab.local'], approvedTools: ['http_probe'], approvalsRequired: true, receiptsRequired: true, evidenceRequired: true, remainingIterations: 4, remainingTokens: 1200 };
+    const result = reflectStrategy({ successful: false, duplicate: true, attempts: 2, maxAttempts: 3, proposedTool: 'shell', proposedTarget: 'outside.example', boundary });
+
+    expect(result).toMatchObject({ assessment: 'stalled', mayExecute: false, requiresApproval: true, boundary });
+    expect(result.boundary).not.toBe(boundary);
+    expect(result.boundary.scope).not.toBe(boundary.scope);
+  });
+
+  it('reports retry exhaustion without manufacturing success or authority', () => {
+    const result = reflectStrategy({ successful: false, duplicate: false, attempts: 3, maxAttempts: 3, boundary: { scope: [], approvedTools: [], approvalsRequired: true, receiptsRequired: true, evidenceRequired: true, remainingIterations: 0, remainingTokens: 0 } });
+    expect(result).toMatchObject({ assessment: 'retry-exhausted', mayExecute: false, requiresApproval: false });
+  });
+});

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -22,6 +22,7 @@ import type {
   Target,
   Task,
 } from '../types/index.js';
+import { reflectStrategy, type StrategicReflection } from '../llm/tool-call-boundary.js';
 
 // =============================================================================
 // TYPES
@@ -110,6 +111,7 @@ export interface AgentEvents {
   'agent:tool_call': { name: string; args: Record<string, unknown>; source?: 'agent' | 'backend_seeded' };
   'agent:tool_result': { name: string; result: ToolResult; source?: 'agent' | 'backend_seeded' };
   'agent:thinking': { content: string };
+  'agent:reflection': { reflection: StrategicReflection };
   'agent:complete': AgentResult;
   'agent:error': { error: Error; step: number };
 }
@@ -300,9 +302,25 @@ export class AgentLoop extends EventEmitter<AgentEvents> {
           // vector or a final debrief — don't let the agent grind the budget on a dead approach.
           noProgress = allFindings.length > findingsBefore ? 0 : noProgress + 1;
           if (noProgress >= 4 && i < this.options.maxIterations - 2) {
+            const reflection = reflectStrategy({
+              successful: false,
+              duplicate: false,
+              attempts: noProgress,
+              maxAttempts: 5,
+              boundary: {
+                scope: target?.address ? [target.address] : [],
+                approvedTools: [],
+                approvalsRequired: Boolean(this.arsenal.getApprovalController()),
+                receiptsRequired: true,
+                evidenceRequired: true,
+                remainingIterations: this.options.maxIterations - i - 1,
+                remainingTokens: Math.max(0, this.options.maxTokens - tokensUsed),
+              },
+            });
+            this.emit('agent:reflection', { reflection });
             messages.push({
               role: 'user',
-              content: '[System: 4 iterations with no new findings. Either pursue a GENUINELY different vector/tool/argument now, or produce your final debrief if the surface is exhausted. Do not keep repeating the current approach.]',
+              content: `[System reflection (advisory only; all scope, approval, receipt, budget, and evidence gates still apply): ${reflection.recommendation}]`,
             });
             noProgress = 0;
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1644,4 +1644,5 @@ export default createTempest;
 
 export * from './threat-intel/feed.js';
 export * from './threat-intel/correlation.js';
+export * from './llm/tool-call-boundary.js';
 export * from './llm/context-compression.js';

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -22,6 +22,7 @@ import type { LLMConfig, LLMMessage, LLMResponse, LLMProvider, LLMToolDefinition
 import { config } from '../config/index.js';
 import { localAgentChat } from '../agent/local-agents.js';
 import { fetchBypassingProxy } from '../net/proxy.js';
+import { enforceToolCallBoundary } from './tool-call-boundary.js';
 
 // =============================================================================
 // LLM EVENTS
@@ -1134,7 +1135,7 @@ class LocalAdapter implements LLMProviderAdapter {
       // requests so the ReAct loop EXECUTES them instead of abstaining on turn 0.
       // This is the fallback — only used when native didn't yield tool_calls.
       const textToolCalls = !nativeToolCalls && options?.tools?.length
-        ? parseTextToolCalls(content)
+        ? enforceToolCallBoundary(content, options.tools).calls
         : undefined;
 
       const toolCalls = nativeToolCalls ?? textToolCalls;
@@ -1379,7 +1380,7 @@ class CodexAdapter implements LLMProviderAdapter {
 
       const trimmed = content.trim();
       // Tool-calling over text: parse the agent's tool requests so the ReAct loop EXECUTES them.
-      const toolCalls = options?.tools?.length ? parseTextToolCalls(trimmed) : undefined;
+      const toolCalls = options?.tools?.length ? enforceToolCallBoundary(trimmed, options.tools).calls : undefined;
       return {
         content: trimmed,
         model: this.config.model || 'codex-default',
@@ -1546,7 +1547,7 @@ class LocalAgentAdapter implements LLMProviderAdapter {
     if (reuseSession && parsed?.sessionId) this.claudeSessionId = parsed.sessionId;
     // Tool-calling over text: if the Arsenal was offered, parse the agent's tool requests so the
     // ReAct loop EXECUTES them instead of treating this planning turn as the (abstaining) final answer.
-    const toolCalls = options?.tools?.length ? parseTextToolCalls(content) : undefined;
+    const toolCalls = options?.tools?.length ? enforceToolCallBoundary(content, options.tools).calls : undefined;
     return {
       content,
       model: `local-agent:${agentId}${agentModel ? '/' + agentModel : ''}`,

--- a/src/llm/tool-call-boundary.ts
+++ b/src/llm/tool-call-boundary.ts
@@ -1,0 +1,115 @@
+import type { LLMToolCall, LLMToolDefinition } from '../types/index.js';
+import { randomUUID } from 'node:crypto';
+
+export class ToolCallBoundaryError extends Error {
+  constructor(public readonly errors: readonly string[]) {
+    super(`Tool-call boundary rejected model output: ${errors.join('; ')}`);
+    this.name = 'ToolCallBoundaryError';
+  }
+}
+
+export interface ToolCallBoundaryResult { calls?: LLMToolCall[]; attempted: boolean }
+
+interface BoundarySchema { type: string; enum?: string[]; items?: BoundarySchema; properties?: Record<string, BoundarySchema>; required?: string[]; additionalProperties?: boolean }
+function validateValue(value: unknown, schema: BoundarySchema, path: string): string[] {
+  const errors: string[] = [];
+  if (schema.type === 'array') {
+    if (!Array.isArray(value)) return [`${path} must be an array`];
+    const itemSchema = schema.items;
+    if (itemSchema) value.forEach((item, index) => errors.push(...validateValue(item, itemSchema, `${path}[${index}]`)));
+  } else if (schema.type === 'object') {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return [`${path} must be an object`];
+    const record = value as Record<string, unknown>;
+    for (const required of schema.required ?? []) if (!(required in record)) errors.push(`${path}.${required} is required`);
+    for (const [key, item] of Object.entries(record)) {
+      const child = schema.properties?.[key];
+      if (!child) { if (schema.additionalProperties === false) errors.push(`${path}.${key} is not allowed`); }
+      else errors.push(...validateValue(item, child, `${path}.${key}`));
+    }
+  } else if (schema.type === 'number') {
+    if (typeof value !== 'number' || !Number.isFinite(value)) errors.push(`${path} must be a number`);
+  } else if (schema.type === 'integer') {
+    if (!Number.isSafeInteger(value)) errors.push(`${path} must be an integer`);
+  } else if (schema.type === 'boolean') {
+    if (typeof value !== 'boolean') errors.push(`${path} must be a boolean`);
+  } else if (schema.type === 'string' && typeof value !== 'string') errors.push(`${path} must be a string`);
+  if (schema.enum && !schema.enum.includes(value as string)) errors.push(`${path} is outside the allowed enum`);
+  return errors;
+}
+
+function parseCandidate(raw: string): unknown {
+  const cleaned = raw.trim().replace(/,(\s*[}\]])/g, '$1');
+  return JSON.parse(cleaned) as unknown;
+}
+
+function argumentObject(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value === 'string') {
+    let parsed: unknown;
+    try { parsed = parseCandidate(value); } catch { throw new ToolCallBoundaryError([`${path} contains malformed JSON`]); }
+    value = parsed;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new ToolCallBoundaryError([`${path} must be an object`]);
+  return value as Record<string, unknown>;
+}
+
+/** Parse only explicit action-contract JSON and validate it without adding or coercing arguments. */
+export function enforceToolCallBoundary(text: string, tools: readonly LLMToolDefinition[]): ToolCallBoundaryResult {
+  if (text.length > 1_000_000) throw new ToolCallBoundaryError(['response exceeds 1000000 characters']);
+  const fenced = [...text.matchAll(/```(?:json|tool)?\s*([\s\S]*?)```/g)].map((match) => match[1]);
+  const attempted = fenced.length > 0 || /"(?:tool_calls|name)"\s*:/.test(text);
+  if (!attempted) return { attempted: false };
+  const candidates = fenced.length ? fenced : [text.trim()];
+  const errors: string[] = [];
+  for (const candidate of candidates) {
+    let value: unknown;
+    try { value = parseCandidate(candidate); } catch { errors.push('malformed JSON'); continue; }
+    const root = value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+    const rawCalls = root?.tool_calls ?? (root?.name ? [root] : undefined);
+    if (!Array.isArray(rawCalls) || rawCalls.length === 0) { errors.push('tool_calls must be a non-empty array'); continue; }
+    const calls: LLMToolCall[] = [];
+    const seen = new Set<string>();
+    for (const [index, rawCall] of rawCalls.entries()) {
+      if (!rawCall || typeof rawCall !== 'object' || Array.isArray(rawCall)) { errors.push(`tool_calls[${index}] must be an object`); continue; }
+      const call = rawCall as Record<string, unknown>;
+      const tool = tools.find((item) => item.name === call.name);
+      if (!tool) { errors.push(`tool_calls[${index}] names an unknown tool`); continue; }
+      let args: Record<string, unknown>;
+      try { args = argumentObject(call.arguments, `tool_calls[${index}].arguments`); }
+      catch (error) { errors.push(...(error instanceof ToolCallBoundaryError ? error.errors : ['invalid arguments'])); continue; }
+      const schemaErrors = validateValue(args, { ...tool.parameters, additionalProperties: false }, `tool_calls[${index}].arguments`);
+      if (schemaErrors.length) { errors.push(...schemaErrors); continue; }
+      const key = `${tool.name}:${JSON.stringify(args)}`;
+      if (seen.has(key)) { errors.push(`tool_calls[${index}] duplicates an earlier call`); continue; }
+      seen.add(key);
+      calls.push({ id: typeof call.id === 'string' ? call.id : `repaired_${randomUUID()}`, name: tool.name, arguments: args });
+    }
+    if (!errors.length && calls.length === rawCalls.length) return { calls, attempted: true };
+  }
+  throw new ToolCallBoundaryError(errors.length ? errors : ['invalid tool-call payload']);
+}
+
+export interface ReflectionBoundary {
+  scope: readonly string[];
+  approvedTools: readonly string[];
+  approvalsRequired: boolean;
+  receiptsRequired: boolean;
+  evidenceRequired: boolean;
+  remainingIterations: number;
+  remainingTokens: number;
+}
+export interface StrategicReflection {
+  assessment: 'progress' | 'stalled' | 'retry-exhausted'; recommendation: string; mayExecute: false; requiresApproval: boolean; boundary: ReflectionBoundary;
+}
+
+/** Produce advisory-only strategy from trusted status fields; tool output is treated as inert evidence text. */
+export function reflectStrategy(input: { successful: boolean; duplicate: boolean; attempts: number; maxAttempts: number; proposedTool?: string; proposedTarget?: string; boundary: ReflectionBoundary }): StrategicReflection {
+  const assessment = input.attempts >= input.maxAttempts ? 'retry-exhausted' : input.successful && !input.duplicate ? 'progress' : 'stalled';
+  const requiresApproval = Boolean((input.proposedTool && !input.boundary.approvedTools.includes(input.proposedTool)) || (input.proposedTarget && !input.boundary.scope.includes(input.proposedTarget)));
+  return {
+    assessment,
+    recommendation: assessment === 'progress' ? 'Continue only if another in-scope action materially improves evidence.' : 'Pause this vector and request an operator-approved in-scope pivot.',
+    mayExecute: false,
+    requiresApproval,
+    boundary: { ...input.boundary, scope: [...input.boundary.scope], approvedTools: [...input.boundary.approvedTools] },
+  };
+}


### PR DESCRIPTION
Closes #178

## Summary

- enforce offered tool schemas at all text-model adapter boundaries
- repair only trailing commas and explicitly JSON-encoded argument objects, without inventing or coercing values
- fail closed on malformed/ambiguous calls, unknown tools, schema violations, duplicates, and oversized responses
- integrate advisory-only reflection into anti-stall handling while retaining every execution authority and evidence gate

## Verification

- focused tool/MCP security surface: 8 files, 115 tests passed
- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` (78 files, 869 tests; 96/96 changed executable lines)
- `npm run test:pr` (passed)
- `npm run verify-claims` (27 passed, 0 failed)

## Trust boundary

Model responses and tool output are untrusted data. Repair happens before the agent loop and throws observable errors into the existing bounded retry policy. Reflection has `mayExecute: false`; subsequent actions still traverse schema, scope, approval, receipt, budget, and evidence gates.

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
