### PR TITLE
feat: add evidence-honest targeted CVE retests

### DIFF
--- a/docs/FINDING_RETEST.md
+++ b/docs/FINDING_RETEST.md
@@ -1,0 +1,7 @@
+# Targeted CVE sweep and finding retest
+
+`FindingRetestWorkflow` records idempotent, provenance-bearing retests without mutating the original finding. A request requires valid CVE identifiers and binds one finding to its original target ID, one tool, and one argument set. Target substitution is rejected before probing. `ArsenalRetestProbe` requires an explicit Arsenal scope and delegates execution through the existing schema, egress-scope, and approval gates.
+
+The probe classifier must explicitly label the observation `present`, `absent`, or `inconclusive` and attach tool evidence. `present` becomes `still_vulnerable` only with successful tool-backed evidence. `absent` becomes `fixed` only with successful tool-backed negative evidence. Empty results, failed probes, timeouts, cancellations, retry exhaustion, missing evidence, and ambiguous observations are always `unverifiable`; absence of a finding is never proof of remediation.
+
+Requests support bounded attempts (1–5), bounded timeouts (100 ms–120 seconds), cooperative cancellation, partial-failure retry, and idempotency keys. Reusing a key for different work is rejected. Each attempt retains timestamps, disposition, evidence, and error provenance. Sweep results remain independent, so one failed target cannot rewrite another finding or corrupt canonical Evidence Vault state.

--- a/src/__tests__/finding-retest.test.ts
+++ b/src/__tests__/finding-retest.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Arsenal } from '../arsenal/index.js';
+import { ArsenalRetestProbe, FindingRetestWorkflow, type ProbeObservation, type RetestRequest } from '../evidence/retest.js';
+import type { Evidence, Finding, Target } from '../types/index.js';
+
+const finding = { id: 'finding-1', title: 'Example CVE', description: 'candidate', severity: 'high', targetId: 'target-1', operatorId: 'op-1', phase: 'exploitation', cve: ['CVE-2026-1234'], evidence: [], discoveredAt: 1 } as Finding;
+const target = { id: 'target-1', name: 'lab', type: 'web_application', address: 'lab.example' } as Target;
+const request = (overrides: Partial<RetestRequest> = {}): RetestRequest => ({ requestId: 'request-1', finding, target, toolName: 'probe', arguments: { url: 'https://lab.example' }, timeoutMs: 200, maxAttempts: 2, ...overrides });
+const evidence = (content = 'HTTP 200 with vulnerable marker'): Evidence[] => [{ type: 'response', content, timestamp: 10, metadata: { source: 'probe' } }];
+const observation = (disposition: ProbeObservation['disposition'], withEvidence = true): ProbeObservation => ({ disposition, evidence: withEvidence ? evidence() : [], result: { success: true, output: 'probe complete' } });
+
+describe('evidence-honest finding retest', () => {
+  it.each([
+    ['present', true, 'still_vulnerable'],
+    ['absent', true, 'fixed'],
+    ['inconclusive', true, 'unverifiable'],
+    ['present', false, 'unverifiable'],
+    ['absent', false, 'unverifiable'],
+  ] as const)('maps %s with evidence=%s to %s', async (disposition, backed, status) => {
+    const workflow = new FindingRetestWorkflow({ run: vi.fn().mockResolvedValue(observation(disposition, backed)) }, () => 100);
+    await expect(workflow.run(request())).resolves.toMatchObject({ status, findingId: finding.id, cve: ['CVE-2026-1234'], provenance: { source: 'authorized-tool-retest' } });
+  });
+
+  it('never interprets an empty successful scan as fixed', async () => {
+    const workflow = new FindingRetestWorkflow({ run: vi.fn().mockResolvedValue({ disposition: 'inconclusive', evidence: [], result: { success: true, findings: [] } }) });
+    await expect(workflow.run(request())).resolves.toHaveProperty('status', 'unverifiable');
+  });
+
+  it('rejects target substitution and non-CVE findings before probing', async () => {
+    const run = vi.fn();
+    const workflow = new FindingRetestWorkflow({ run });
+    await expect(workflow.run(request({ target: { ...target, id: 'other' } }))).rejects.toThrow('must match');
+    await expect(workflow.run(request({ requestId: 'no-cve', finding: { ...finding, cve: [] } }))).rejects.toThrow('valid CVE');
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('retries explicit partial failures and preserves every attempt', async () => {
+    const run = vi.fn()
+      .mockResolvedValueOnce({ ...observation('inconclusive'), retryable: true, result: { success: false, error: 'partial response' } })
+      .mockResolvedValueOnce(observation('present'));
+    const result = await new FindingRetestWorkflow({ run }, () => 100).run(request());
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ status: 'still_vulnerable', attempts: [{ disposition: 'inconclusive', error: 'partial response' }, { disposition: 'present' }] });
+  });
+
+  it('returns the same promise/result for an idempotent request and rejects key reuse', async () => {
+    const run = vi.fn().mockResolvedValue(observation('present'));
+    const workflow = new FindingRetestWorkflow({ run });
+    const first = workflow.run(request());
+    const second = workflow.run(request());
+    expect(second).toBe(first);
+    expect((await second).id).toBe((await first).id);
+    expect(run).toHaveBeenCalledTimes(1);
+    await expect(workflow.run(request({ toolName: 'different' }))).rejects.toThrow('different retest');
+  });
+
+  it('times out, exhausts retries, and remains unverifiable', async () => {
+    vi.useFakeTimers();
+    const run = vi.fn((_request: RetestRequest, signal: AbortSignal) => new Promise<ProbeObservation>((_resolve, reject) => signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })));
+    const promise = new FindingRetestWorkflow({ run }).run(request({ timeoutMs: 100, maxAttempts: 2 }));
+    await vi.advanceTimersByTimeAsync(250);
+    const result = await promise;
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe('unverifiable');
+    expect(result.attempts.every((attempt) => attempt.error === 'Retest timed out')).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('honors cancellation without retrying or changing finding state', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const run = vi.fn();
+    const result = await new FindingRetestWorkflow({ run }).run(request({ signal: controller.signal, maxAttempts: 5 }));
+    expect(run).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: 'unverifiable', attempts: [{ error: 'Retest cancelled' }] });
+    expect(finding).not.toHaveProperty('retestStatus');
+  });
+
+  it('isolates sweep failures through unverifiable records', async () => {
+    const probe = { run: vi.fn().mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce(observation('present')) };
+    const results = await new FindingRetestWorkflow(probe).sweep([request({ requestId: 'a', maxAttempts: 1 }), request({ requestId: 'b' })]);
+    expect(results.map(({ status }) => status)).toEqual(['unverifiable', 'still_vulnerable']);
+  });
+});
+
+describe('Arsenal retest adapter', () => {
+  it('refuses execution without an explicit scope', async () => {
+    const arsenal = new Arsenal();
+    const probe = new ArsenalRetestProbe(arsenal, () => observation('present'));
+    await expect(probe.run(request(), new AbortController().signal)).rejects.toThrow('explicit Arsenal scope');
+  });
+
+  it('delegates to Arsenal so out-of-scope probes fail before the handler', async () => {
+    const arsenal = new Arsenal();
+    const handler = vi.fn().mockResolvedValue({ success: true, output: 'hit' });
+    arsenal.register({ name: 'probe', description: 'probe', category: 'web', parameters: [], handler });
+    arsenal.setScope({ allowedHosts: ['lab.example'], allowLoopback: false, allowPrivate: false });
+    const probe = new ArsenalRetestProbe(arsenal, (result) => ({ disposition: 'inconclusive', evidence: [], result }));
+    const result = await probe.run(request({ arguments: { url: 'https://outside.example' } }), new AbortController().signal);
+    expect(result.result.error).toContain('SCOPE DENIED');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('refuses a cancelled request before Arsenal execution', async () => {
+    const arsenal = new Arsenal();
+    arsenal.setScope({ allowedHosts: ['lab.example'], allowLoopback: false, allowPrivate: false });
+    const controller = new AbortController();
+    controller.abort();
+    const probe = new ArsenalRetestProbe(arsenal, () => observation('present'));
+    await expect(probe.run(request(), controller.signal)).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/src/evidence/retest.ts
+++ b/src/evidence/retest.ts
@@ -1,0 +1,145 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type { Arsenal } from '../arsenal/index.js';
+import type { Evidence, Finding, Target, ToolResult } from '../types/index.js';
+
+export type RetestStatus = 'fixed' | 'still_vulnerable' | 'unverifiable';
+export type ProbeDisposition = 'present' | 'absent' | 'inconclusive';
+
+export interface ProbeObservation {
+  disposition: ProbeDisposition;
+  evidence: Evidence[];
+  result: ToolResult;
+  retryable?: boolean;
+}
+
+export interface RetestRequest {
+  requestId: string;
+  finding: Finding;
+  target: Target;
+  toolName: string;
+  arguments: Record<string, unknown>;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  signal?: AbortSignal;
+}
+
+export interface RetestAttempt {
+  attempt: number;
+  startedAt: number;
+  completedAt: number;
+  disposition: ProbeDisposition;
+  evidence: Evidence[];
+  error?: string;
+}
+
+export interface RetestRecord {
+  id: string;
+  requestId: string;
+  findingId: string;
+  cve: string[];
+  targetId: string;
+  toolName: string;
+  status: RetestStatus;
+  attempts: RetestAttempt[];
+  provenance: { source: 'authorized-tool-retest'; createdAt: number };
+}
+
+export interface RetestProbe {
+  run(request: RetestRequest, signal: AbortSignal): Promise<ProbeObservation>;
+}
+
+const TOOL_EVIDENCE = new Set<Evidence['type']>(['log', 'request', 'response', 'file', 'command', 'output']);
+function copyEvidence(items: readonly Evidence[]): Evidence[] {
+  return items.map((item) => ({ ...item, metadata: item.metadata ? { ...item.metadata } : undefined }));
+}
+function hasToolEvidence(items: readonly Evidence[]): boolean {
+  return items.some((item) => TOOL_EVIDENCE.has(item.type) && item.content.trim().length > 0);
+}
+function fingerprint(request: RetestRequest): string {
+  return createHash('sha256').update(JSON.stringify({ findingId: request.finding.id, targetId: request.target.id, toolName: request.toolName, arguments: request.arguments })).digest('hex');
+}
+function abortError(message = 'Retest cancelled'): Error {
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+}
+
+/** Arsenal adapter: scope must be configured; Arsenal still owns schema, scope, and approval gates. */
+export class ArsenalRetestProbe implements RetestProbe {
+  constructor(private readonly arsenal: Arsenal, private readonly classify: (result: ToolResult) => ProbeObservation) {}
+
+  async run(request: RetestRequest, signal: AbortSignal): Promise<ProbeObservation> {
+    if (!this.arsenal.getScope()) throw new Error('Retest refused: an explicit Arsenal scope is required');
+    if (signal.aborted) throw abortError();
+    const result = await this.arsenal.execute(request.toolName, { target: request.target, parameters: { ...request.arguments } });
+    if (signal.aborted) throw abortError();
+    return this.classify(result);
+  }
+}
+
+export class FindingRetestWorkflow {
+  private readonly completed = new Map<string, { fingerprint: string; result: Promise<RetestRecord> }>();
+
+  constructor(private readonly probe: RetestProbe, private readonly now: () => number = Date.now) {}
+
+  run(request: RetestRequest): Promise<RetestRecord> {
+    if (!request.requestId.trim()) return Promise.reject(new Error('requestId is required'));
+    if (!request.finding.id || !request.target.id || !request.toolName.trim()) return Promise.reject(new Error('finding, target, and toolName are required'));
+    if (request.finding.targetId !== request.target.id) return Promise.reject(new Error('retest target must match the finding target'));
+    if (!request.finding.cve?.length || request.finding.cve.some((id) => !/^CVE-\d{4}-\d{4,}$/i.test(id))) return Promise.reject(new Error('targeted retest requires valid CVE identifiers'));
+    const key = fingerprint(request);
+    const prior = this.completed.get(request.requestId);
+    if (prior) {
+      if (prior.fingerprint !== key) return Promise.reject(new Error('requestId was already used for a different retest'));
+      return prior.result;
+    }
+    const result = this.execute(request);
+    this.completed.set(request.requestId, { fingerprint: key, result });
+    return result;
+  }
+
+  async sweep(requests: readonly RetestRequest[]): Promise<RetestRecord[]> {
+    return Promise.all(requests.map((request) => this.run(request)));
+  }
+
+  private async execute(request: RetestRequest): Promise<RetestRecord> {
+    const maxAttempts = Math.min(5, Math.max(1, request.maxAttempts ?? 2));
+    const timeoutMs = Math.min(120_000, Math.max(100, request.timeoutMs ?? 20_000));
+    const attempts: RetestAttempt[] = [];
+    let final: ProbeObservation | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (request.signal?.aborted) {
+        attempts.push({ attempt, startedAt: this.now(), completedAt: this.now(), disposition: 'inconclusive', evidence: [], error: 'Retest cancelled' });
+        break;
+      }
+      const startedAt = this.now();
+      const controller = new AbortController();
+      const onAbort = () => controller.abort();
+      request.signal?.addEventListener('abort', onAbort, { once: true });
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        final = await this.probe.run(request, controller.signal);
+        attempts.push({ attempt, startedAt, completedAt: this.now(), disposition: final.disposition, evidence: copyEvidence(final.evidence), ...(final.result.error ? { error: final.result.error } : {}) });
+        if (!final.retryable) break;
+      } catch (error) {
+        const cancelled = request.signal?.aborted;
+        attempts.push({ attempt, startedAt, completedAt: this.now(), disposition: 'inconclusive', evidence: [], error: cancelled ? 'Retest cancelled' : controller.signal.aborted ? 'Retest timed out' : error instanceof Error ? error.message : String(error) });
+        if (cancelled) break;
+      } finally {
+        clearTimeout(timer);
+        request.signal?.removeEventListener('abort', onAbort);
+      }
+    }
+    const evidenceBacked = Boolean(final && final.result.success && hasToolEvidence(final.evidence));
+    const status: RetestStatus = evidenceBacked && final?.disposition === 'present'
+      ? 'still_vulnerable'
+      : evidenceBacked && final?.disposition === 'absent'
+        ? 'fixed'
+        : 'unverifiable';
+    return {
+      id: randomUUID(), requestId: request.requestId, findingId: request.finding.id, cve: [...(request.finding.cve ?? [])],
+      targetId: request.target.id, toolName: request.toolName, status, attempts,
+      provenance: { source: 'authorized-tool-retest', createdAt: this.now() },
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1645,4 +1645,5 @@ export default createTempest;
 export * from './threat-intel/feed.js';
 export * from './threat-intel/correlation.js';
 export * from './llm/tool-call-boundary.js';
+export * from './evidence/retest.js';
 export * from './llm/context-compression.js';


### PR DESCRIPTION
Closes #174

## Summary

- add an idempotent targeted-CVE retest workflow with per-attempt provenance
- require the original finding target, valid CVE identifiers, explicit Arsenal scope, and existing schema/scope/approval execution gates
- report `fixed` or `still_vulnerable` only from successful tool-backed evidence; all ambiguous, empty, failed, timed-out, or cancelled probes remain `unverifiable`
- cover bounded retry, partial failure, timeout, cancellation, idempotency, target substitution, and sweep isolation

## Verification

- focused retest and Arsenal risk surface: 3 files, 32 tests passed
- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` (79 files, 885 tests; 66/66 changed executable lines)
- `npm run test:pr` (79 files, 885 tests; passed)
- `npm run verify-claims` (27 passed, 0 failed)

## Evidence boundary

The workflow never mutates the canonical finding. Absence of a returned finding is not remediation evidence. A classifier must explicitly provide a successful `absent` observation plus tool evidence before the status can become `fixed`.

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
