### PR TITLE
feat: add scoped honeytoken lifecycle

### DIFF
--- a/docs/HONEYTOKENS.md
+++ b/docs/HONEYTOKENS.md
@@ -1,0 +1,9 @@
+# Scoped honeytokens and tripwires
+
+`HoneytokenManager` is an opt-in, in-memory lifecycle service. Creation returns token material to the authorized deployment caller exactly once; list, trigger, alert, error, and audit surfaces contain metadata or keyed hashes, never the token. Callers must not log the returned material or pass it into model context, findings, fixtures, command-line arguments, or persistent storage.
+
+Lifecycle states are `created`, `active`, and `revoked`. Activation fails closed unless the token's environment appears in the manager's explicit allowlist. Rotation revokes and zeroes the old in-process buffer and returns a new inactive generation. Revocation removes lookup capability and zeroes the buffer; cleanup additionally removes the record. These are process-memory controls, not claims of secure deletion from caller memory, swap, crash dumps, or external deployment targets.
+
+Triggers require an active token, a timestamp within five minutes, a nonce, and `HMAC-SHA-256(token, nonce:timestamp)`. Used nonces are retained as keyed hashes and rejected on replay. Token material, nonce text, and source identifiers are absent from events; sources and nonces are represented by audit-keyed hashes. New triggers start `pending` and require an operator to classify them `confirmed` or `dismissed`, preserving false-positive review.
+
+Audit events record lifecycle action, public token ID, actor, timestamp, and non-secret transition detail. Alerts use the `HoneytokenAlertSink` interface only; a delivery failure cannot roll back or corrupt the trigger. Concrete Slack, Discord, and SIEM delivery belongs to #176.

--- a/src/__tests__/honeytokens.test.ts
+++ b/src/__tests__/honeytokens.test.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { HoneytokenManager } from '../deception/honeytokens.js';
+
+const NOW = 1_800_000_000_000;
+const manager = (environments = new Set(['lab']), deliver?: (event: never) => Promise<void>) =>
+  new HoneytokenManager(randomBytes(32), environments, deliver ? { deliver } : undefined, () => NOW);
+const create = (subject: HoneytokenManager, environment = 'lab') => subject.create({ label: 'database decoy', kind: 'credential', environment, actor: 'operator' });
+
+describe('scoped honeytoken lifecycle', () => {
+  it('returns secret material once while list and audit surfaces remain secret-free', () => {
+    const subject = manager();
+    const material = create(subject);
+    expect(material.token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    const outward = JSON.stringify({ list: subject.list(), audit: subject.getAudit() });
+    expect(outward).not.toContain(material.token);
+    expect(outward).not.toContain('auditKey');
+    expect(subject.list()[0]).not.toHaveProperty('token');
+  });
+
+  it('fails closed when activation is not authorized for the environment', () => {
+    const subject = manager(new Set(['production']));
+    const material = create(subject, 'lab');
+    expect(() => subject.activate(material.metadata.id, 'operator')).toThrow('not authorized');
+    expect(subject.list()[0].state).toBe('created');
+  });
+
+  it('supports activate, rotate, revoke, and cleanup with auditable transitions', async () => {
+    const subject = manager();
+    const first = create(subject);
+    expect(subject.activate(first.metadata.id, 'operator')).toMatchObject({ state: 'active', generation: 1 });
+    const replacement = subject.rotate(first.metadata.id, 'operator');
+    expect(replacement.token).not.toBe(first.token);
+    expect(replacement.metadata).toMatchObject({ state: 'created', generation: 2 });
+    expect(subject.list().find(({ id }) => id === first.metadata.id)?.state).toBe('revoked');
+    const signature = subject.signTrigger(first.token, 'old-token', NOW);
+    await expect(subject.trigger({ token: first.token, nonce: 'old-token', occurredAt: NOW, signature, source: '192.0.2.1' })).resolves.toBeUndefined();
+    subject.activate(replacement.metadata.id, 'operator');
+    expect(subject.cleanup(replacement.metadata.id, 'operator')).toBe(true);
+    expect(subject.cleanup(replacement.metadata.id, 'operator')).toBe(false);
+    expect(subject.getAudit().map(({ action }) => action)).toEqual(['created', 'activated', 'revoked', 'created', 'rotated', 'activated', 'cleaned']);
+  });
+
+  it('rejects arbitrary secret-shaped metadata instead of exporting it', () => {
+    const subject = manager();
+    expect(() => subject.create({ label: 'token=very-secret-value', kind: 'opaque', environment: 'lab', actor: 'operator' })).toThrow('unsupported metadata');
+    expect(() => subject.create({ label: 'safe', kind: 'opaque', environment: '../prod', actor: 'operator' })).toThrow('unsupported metadata');
+  });
+
+  it('copies the caller-owned key at construction', async () => {
+    const key = randomBytes(32);
+    const subject = new HoneytokenManager(key, new Set(['lab']), undefined, () => NOW);
+    const material = create(subject);
+    subject.activate(material.metadata.id, 'operator');
+    key.fill(0);
+    const nonce = 'independent-key-copy';
+    const event = await subject.trigger({ token: material.token, nonce, occurredAt: NOW, signature: subject.signTrigger(material.token, nonce, NOW), source: '198.51.100.2' });
+    expect(event).toBeDefined();
+  });
+});
+
+describe('trigger provenance and replay handling', () => {
+  it('authenticates a fresh trigger, hashes sensitive metadata, and rejects replay', async () => {
+    const subject = manager();
+    const material = create(subject);
+    subject.activate(material.metadata.id, 'operator');
+    const nonce = 'unique-request-nonce';
+    const source = '203.0.113.99';
+    const signature = subject.signTrigger(material.token, nonce, NOW);
+    const event = await subject.trigger({ token: material.token, nonce, occurredAt: NOW, signature, source });
+    expect(event).toMatchObject({ tokenId: material.metadata.id, classification: 'pending', provenance: 'authenticated-honeytoken-use' });
+    const serialized = JSON.stringify({ event, audit: subject.getAudit() });
+    expect(serialized).not.toContain(material.token);
+    expect(serialized).not.toContain(nonce);
+    expect(serialized).not.toContain(source);
+    await expect(subject.trigger({ token: material.token, nonce, occurredAt: NOW, signature, source })).resolves.toBeUndefined();
+    expect(subject.getAudit().at(-1)?.action).toBe('replay-rejected');
+  });
+
+  it('rejects stale, forged, inactive, and empty-nonce triggers', async () => {
+    const subject = manager();
+    const material = create(subject);
+    const call = (nonce: string, occurredAt: number, signature: string) => subject.trigger({ token: material.token, nonce, occurredAt, signature, source: 'source' });
+    const valid = subject.signTrigger(material.token, 'nonce', NOW);
+    await expect(call('nonce', NOW, valid)).resolves.toBeUndefined();
+    subject.activate(material.metadata.id, 'operator');
+    await expect(call('', NOW, valid)).resolves.toBeUndefined();
+    await expect(call('nonce', NOW - 300_001, valid)).resolves.toBeUndefined();
+    await expect(call('nonce', NOW, 'forged')).resolves.toBeUndefined();
+  });
+
+  it('supports explicit false-positive classification with audit provenance', async () => {
+    const subject = manager();
+    const material = create(subject);
+    subject.activate(material.metadata.id, 'operator');
+    const nonce = 'classification';
+    const event = await subject.trigger({ token: material.token, nonce, occurredAt: NOW, signature: subject.signTrigger(material.token, nonce, NOW), source: 'source' });
+    expect(event).toBeDefined();
+    const classified = subject.classify(event?.id ?? '', 'dismissed', 'reviewer');
+    expect(classified.classification).toBe('dismissed');
+    expect(subject.getAudit().at(-1)).toMatchObject({ action: 'classified', actor: 'reviewer' });
+  });
+
+  it('isolates alert delivery failure from trigger state', async () => {
+    const deliver = vi.fn().mockRejectedValue(new Error('dispatcher unavailable'));
+    const subject = manager(new Set(['lab']), deliver);
+    const material = create(subject);
+    subject.activate(material.metadata.id, 'operator');
+    const nonce = 'delivery-failure';
+    const event = await subject.trigger({ token: material.token, nonce, occurredAt: NOW, signature: subject.signTrigger(material.token, nonce, NOW), source: 'source' });
+    expect(deliver).toHaveBeenCalledOnce();
+    expect(event).toMatchObject({ classification: 'pending' });
+    expect(subject.getAudit().at(-1)?.action).toBe('triggered');
+  });
+});

--- a/src/deception/honeytokens.ts
+++ b/src/deception/honeytokens.ts
@@ -1,0 +1,144 @@
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { redactString } from '../redact.js';
+
+export type HoneytokenState = 'created' | 'active' | 'revoked';
+export type HoneytokenKind = 'opaque' | 'api-key' | 'credential' | 'beacon';
+export type TriggerClassification = 'pending' | 'confirmed' | 'dismissed';
+export interface HoneytokenMetadata { id: string; label: string; kind: HoneytokenKind; environment: string; state: HoneytokenState; generation: number; createdAt: number; activatedAt?: number; revokedAt?: number }
+export interface HoneytokenMaterial { metadata: HoneytokenMetadata; token: string }
+export interface HoneytokenAudit { id: string; action: 'created' | 'activated' | 'rotated' | 'revoked' | 'cleaned' | 'triggered' | 'classified' | 'replay-rejected'; tokenId: string; at: number; actor: string; detail?: string }
+export interface HoneytokenTrigger { id: string; tokenId: string; at: number; nonceHash: string; sourceHash: string; classification: TriggerClassification; provenance: 'authenticated-honeytoken-use' }
+export interface HoneytokenAlertSink { deliver(event: HoneytokenTrigger): Promise<void> }
+
+interface StoredToken { metadata: HoneytokenMetadata; token: Buffer; digest: string; nonces: Set<string> }
+const cloneMetadata = (item: HoneytokenMetadata): HoneytokenMetadata => ({ ...item });
+
+export class HoneytokenManager {
+  private readonly tokens = new Map<string, StoredToken>();
+  private readonly byDigest = new Map<string, string>();
+  private readonly triggers = new Map<string, HoneytokenTrigger>();
+  private readonly audits: HoneytokenAudit[] = [];
+  private readonly auditKey: Buffer;
+
+  constructor(
+    auditKey: Uint8Array,
+    private readonly authorizedEnvironments: ReadonlySet<string>,
+    private readonly alertSink?: HoneytokenAlertSink,
+    private readonly now: () => number = Date.now,
+  ) {
+    if (auditKey.byteLength < 32) throw new Error('Honeytoken audit key must contain at least 32 bytes');
+    this.auditKey = Buffer.from(auditKey);
+  }
+
+  create(input: { label: string; kind: HoneytokenKind; environment: string; actor: string }): HoneytokenMaterial {
+    if (!input.label.trim() || !input.kind.trim() || !input.environment.trim() || !input.actor.trim()) throw new Error('label, kind, environment, and actor are required');
+    if (!/^[a-zA-Z0-9 ._-]{1,100}$/.test(input.label) || !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(input.environment)) throw new Error('label or environment contains unsupported metadata characters');
+    const id = randomUUID();
+    const token = randomBytes(32);
+    const metadata: HoneytokenMetadata = { id, label: redactString(input.label), kind: input.kind, environment: input.environment, state: 'created', generation: 1, createdAt: this.now() };
+    const stored = { metadata, token, digest: this.digest(token), nonces: new Set<string>() };
+    this.tokens.set(id, stored);
+    this.byDigest.set(stored.digest, id);
+    this.audit('created', id, input.actor);
+    return { metadata: cloneMetadata(metadata), token: token.toString('base64url') };
+  }
+
+  activate(id: string, actor: string): HoneytokenMetadata {
+    this.requireActor(actor);
+    const item = this.require(id);
+    if (!this.authorizedEnvironments.has(item.metadata.environment)) throw new Error('Honeytoken deployment is not authorized for this environment');
+    if (item.metadata.state !== 'created') throw new Error('Only a newly created honeytoken may be activated');
+    item.metadata.state = 'active';
+    item.metadata.activatedAt = this.now();
+    this.audit('activated', id, actor);
+    return cloneMetadata(item.metadata);
+  }
+
+  rotate(id: string, actor: string): HoneytokenMaterial {
+    this.requireActor(actor);
+    const old = this.require(id);
+    this.revoke(id, actor);
+    const material = this.create({ label: old.metadata.label, kind: old.metadata.kind, environment: old.metadata.environment, actor });
+    const replacement = this.require(material.metadata.id);
+    replacement.metadata.generation = old.metadata.generation + 1;
+    material.metadata.generation = replacement.metadata.generation;
+    this.audit('rotated', replacement.metadata.id, actor, `replaces:${id}`);
+    return material;
+  }
+
+  revoke(id: string, actor: string): HoneytokenMetadata {
+    this.requireActor(actor);
+    const item = this.require(id);
+    if (item.metadata.state !== 'revoked') {
+      item.metadata.state = 'revoked';
+      item.metadata.revokedAt = this.now();
+      this.byDigest.delete(item.digest);
+      item.token.fill(0);
+      this.audit('revoked', id, actor);
+    }
+    return cloneMetadata(item.metadata);
+  }
+
+  cleanup(id: string, actor: string): boolean {
+    this.requireActor(actor);
+    const item = this.tokens.get(id);
+    if (!item) return false;
+    this.byDigest.delete(item.digest);
+    item.token.fill(0);
+    this.tokens.delete(id);
+    this.audit('cleaned', id, actor);
+    return true;
+  }
+
+  signTrigger(token: string, nonce: string, occurredAt: number): string {
+    return createHmac('sha256', Buffer.from(token, 'base64url')).update(`${nonce}:${occurredAt}`).digest('base64url');
+  }
+
+  async trigger(input: { token: string; nonce: string; occurredAt: number; signature: string; source: string }): Promise<HoneytokenTrigger | undefined> {
+    if (!input.nonce || Math.abs(this.now() - input.occurredAt) > 5 * 60_000) return undefined;
+    const raw = Buffer.from(input.token, 'base64url');
+    const id = this.byDigest.get(this.digest(raw));
+    const item = id ? this.tokens.get(id) : undefined;
+    if (!item || item.metadata.state !== 'active') return undefined;
+    const expected = createHmac('sha256', item.token).update(`${input.nonce}:${input.occurredAt}`).digest();
+    let supplied: Buffer;
+    try { supplied = Buffer.from(input.signature, 'base64url'); } catch { return undefined; }
+    if (supplied.length !== expected.length || !timingSafeEqual(supplied, expected)) return undefined;
+    const nonceHash = this.keyed(input.nonce);
+    if (item.nonces.has(nonceHash)) {
+      this.audit('replay-rejected', item.metadata.id, 'system');
+      return undefined;
+    }
+    if (item.nonces.size >= 10_000) return undefined;
+    item.nonces.add(nonceHash);
+    const event: HoneytokenTrigger = { id: randomUUID(), tokenId: item.metadata.id, at: this.now(), nonceHash, sourceHash: this.keyed(input.source), classification: 'pending', provenance: 'authenticated-honeytoken-use' };
+    this.triggers.set(event.id, event);
+    this.audit('triggered', item.metadata.id, 'system', `event:${event.id}`);
+    try { await this.alertSink?.deliver({ ...event }); } catch { /* delivery cannot corrupt lifecycle state */ }
+    return { ...event };
+  }
+
+  classify(eventId: string, classification: Exclude<TriggerClassification, 'pending'>, actor: string): HoneytokenTrigger {
+    this.requireActor(actor);
+    const event = this.triggers.get(eventId);
+    if (!event) throw new Error('Trigger event not found');
+    event.classification = classification;
+    this.audit('classified', event.tokenId, actor, `event:${event.id}:${classification}`);
+    return { ...event };
+  }
+
+  list(): HoneytokenMetadata[] { return [...this.tokens.values()].map(({ metadata }) => cloneMetadata(metadata)); }
+  getAudit(): HoneytokenAudit[] { return this.audits.map((item) => ({ ...item })); }
+
+  private require(id: string): StoredToken {
+    const item = this.tokens.get(id);
+    if (!item) throw new Error('Honeytoken not found');
+    return item;
+  }
+  private requireActor(actor: string): void { if (!actor.trim()) throw new Error('actor is required'); }
+  private digest(value: Uint8Array): string { return createHmac('sha256', this.auditKey).update(value).digest('base64url'); }
+  private keyed(value: string): string { return createHmac('sha256', this.auditKey).update(value).digest('base64url'); }
+  private audit(action: HoneytokenAudit['action'], tokenId: string, actor: string, detail?: string): void {
+    this.audits.push({ id: randomUUID(), action, tokenId, at: this.now(), actor: redactString(actor), ...(detail ? { detail } : {}) });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1646,4 +1646,5 @@ export * from './threat-intel/feed.js';
 export * from './threat-intel/correlation.js';
 export * from './llm/tool-call-boundary.js';
 export * from './evidence/retest.js';
+export * from './deception/honeytokens.js';
 export * from './llm/context-compression.js';


### PR DESCRIPTION
Closes #175

## Summary

- add an opt-in, in-memory honeytoken lifecycle with explicit environment authorization
- keep raw token material out of list, audit, trigger, alert, error, finding, and model-facing surfaces
- implement activation, rotation, revocation, cleanup, keyed source/nonce provenance, authenticated trigger receipts, and replay rejection
- require operator classification of pending triggers and isolate alert delivery behind an interface

## Verification

- focused honeytoken and redaction surface: 3 files, 19 tests passed
- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` (91/91 changed executable lines)
- `npm run test:pr` (80 files, 894 tests; passed)
- `npm run verify-claims` (27 passed, 0 failed)

## Secret boundary

Creation/rotation return deployment material once to the caller. Manager-owned key material is copied; live token buffers are zeroed on revoke/cleanup. Public identifiers and source/nonce provenance are keyed hashes. The implementation makes no claim that caller-held strings, swap, or crash dumps are zeroized.

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
