### PR TITLE
feat: add secure alert delivery

### DIFF
--- a/docs/ALERT_DELIVERY.md
+++ b/docs/ALERT_DELIVERY.md
@@ -1,0 +1,9 @@
+# Secure outbound alert delivery
+
+`AlertDispatcher` sends redacted security-event summaries to Slack, Discord, and generic SIEM webhooks. Destinations are optional and resolved only from the fixed server-side environment keys `SLACK_WEBHOOK_URL`, `DISCORD_WEBHOOK_URL`, and `SIEM_WEBHOOK_URL`. URLs are private runtime state: list and receipt surfaces expose only destination ID, provider, configured status, allowlisted hostname, and proxy policy. The module does not load `.env` files or add browser/configuration APIs.
+
+Every configured URL must use HTTPS, contain no URL userinfo or fragment, and match an exact hostname allowlist. Redirect following is disabled. Slack and Discord ship with narrow default hosts; SIEM is omitted until an operator supplies its host allowlist. Each destination explicitly selects `configured` routing (the process-wide configured proxy) or `direct` routing.
+
+Alerts are recursively redacted before provider-specific serialization. Payloads above the configured byte limit are rejected before network use. Delivery uses explicit timeouts, bounded exponential retry for network errors, timeout, HTTP 408/429, and 5xx responses, no retry for terminal 4xx responses, and per-destination rate limiting. Receipts use fixed error categories and never include provider response bodies, exception text, or webhook URLs.
+
+Delivery returns isolated receipts and does not mutate the alert, mission, finding, or honeytoken event. The `HoneytokenAlertSink` adapter raises a generic failure only after recording the trigger independently; destination failure cannot corrupt security state. Data leaving the system is limited to the redacted provider payload at dispatch time: event name, title, details, timestamp, optional severity/target, and redacted metadata.

--- a/src/__tests__/alerts.test.ts
+++ b/src/__tests__/alerts.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { AlertDispatcher, defaultAlertDestinations, type AlertDestinationSpec, type SecurityAlert } from '../integrations/alerts.js';
+
+const secretUrl = (host = 'hooks.slack.com') => `https://${host}/services/${crypto.randomUUID()}`;
+const alert = (overrides: Partial<SecurityAlert> = {}): SecurityAlert => ({ event: 'finding_discovered', title: 'Finding', details: 'Evidence observed', occurredAt: 1_800_000_000_000, severity: 'high', target: 'lab.example', ...overrides });
+const spec = (overrides: Partial<AlertDestinationSpec> = {}): AlertDestinationSpec => ({ id: 'slack', provider: 'slack', envKey: 'SLACK_WEBHOOK_URL', allowedHosts: ['hooks.slack.com'], proxyPolicy: 'configured', rateLimitMs: 0, ...overrides });
+const response = (status = 200) => new Response('', { status });
+
+describe('secure alert destination configuration', () => {
+  it('loads only fixed environment keys and never returns secret URLs', () => {
+    const url = secretUrl();
+    const dispatcher = new AlertDispatcher([spec()], { environment: { SLACK_WEBHOOK_URL: url } });
+    const listed = dispatcher.listDestinations();
+    expect(listed).toEqual([{ id: 'slack', provider: 'slack', configured: true, host: 'hooks.slack.com', proxyPolicy: 'configured' }]);
+    expect(JSON.stringify(listed)).not.toContain(url);
+    expect(JSON.stringify(listed)).not.toContain(url.split('/').at(-1));
+  });
+
+  it.each([
+    ['http://hooks.slack.com/services/x', 'HTTPS'],
+    ['https://user:pass@hooks.slack.com/services/x', 'credential-free'],
+    ['https://attacker.example/services/x', 'allowlisted'],
+  ])('rejects unsafe destination %s', (url, message) => {
+    expect(() => new AlertDispatcher([spec()], { environment: { SLACK_WEBHOOK_URL: url } })).toThrow(message);
+  });
+
+  it('reports an absent environment key without making a request', async () => {
+    const fetch = vi.fn();
+    const receipts = await new AlertDispatcher([spec()], { environment: {}, configuredFetch: fetch }).dispatch(alert());
+    expect(receipts).toEqual([{ destinationId: 'slack', provider: 'slack', delivered: false, attempts: 0, error: 'not-configured' }]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not add SIEM until an explicit host allowlist exists', () => {
+    expect(defaultAlertDestinations().map(({ provider }) => provider)).toEqual(['slack', 'discord']);
+    expect(defaultAlertDestinations(['siem.internal']).at(-1)).toMatchObject({ provider: 'siem', allowedHosts: ['siem.internal'] });
+  });
+});
+
+describe('provider payload and secret boundaries', () => {
+  it('rejects malformed runtime alert fields before delivery', async () => {
+    const fetcher = vi.fn();
+    const dispatcher = new AlertDispatcher([spec()], { environment: { SLACK_WEBHOOK_URL: 'https://hooks.slack.com/services/secret' }, configuredFetch: fetcher });
+    await expect(dispatcher.dispatch(alert({ occurredAt: 9e99 }))).rejects.toThrow('required');
+    await expect(dispatcher.dispatch(alert({ severity: 'urgent' as SecurityAlert['severity'] }))).rejects.toThrow('severity');
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['slack', 'SLACK_WEBHOOK_URL', 'hooks.slack.com'],
+    ['discord', 'DISCORD_WEBHOOK_URL', 'discord.com'],
+    ['siem', 'SIEM_WEBHOOK_URL', 'siem.internal'],
+  ] as const)('sends an isolated %s contract with redaction and no redirect following', async (provider, envKey, host) => {
+    const url = secretUrl(host);
+    const fetch = vi.fn().mockResolvedValue(response());
+    const dispatcher = new AlertDispatcher([spec({ id: provider, provider, envKey, allowedHosts: [host] })], { environment: { [envKey]: url }, configuredFetch: fetch });
+    const receipts = await dispatcher.dispatch(alert({ details: 'token=do-not-send', metadata: { apiKey: 'also-private', safe: 'yes' } }));
+    expect(receipts).toEqual([{ destinationId: provider, provider, delivered: true, attempts: 1, status: 200 }]);
+    const [calledUrl, init] = fetch.mock.calls[0];
+    expect(calledUrl).toBe(url);
+    expect(init).toMatchObject({ method: 'POST', redirect: 'manual' });
+    expect(init.body).not.toContain('do-not-send');
+    expect(init.body).not.toContain('also-private');
+    expect(init.body).toContain('[redacted]');
+    expect(init.body).toContain('Finding');
+  });
+
+  it('rejects oversized redacted payloads before network use', async () => {
+    const fetch = vi.fn();
+    const receipt = await new AlertDispatcher([spec({ maxPayloadBytes: 1024 })], { environment: { SLACK_WEBHOOK_URL: secretUrl() }, configuredFetch: fetch }).dispatch(alert({ details: 'x'.repeat(2_000) }));
+    expect(receipt[0]).toMatchObject({ delivered: false, attempts: 0, error: 'payload-too-large' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('delivery reliability controls', () => {
+  it('routes configured and direct policies through separate fetchers', async () => {
+    const configuredFetch = vi.fn().mockResolvedValue(response());
+    const directFetch = vi.fn().mockResolvedValue(response());
+    const specs = [spec({ id: 'proxied' }), spec({ id: 'direct', envKey: 'SIEM_WEBHOOK_URL', proxyPolicy: 'direct' })];
+    await new AlertDispatcher(specs, { environment: { SLACK_WEBHOOK_URL: secretUrl(), SIEM_WEBHOOK_URL: secretUrl() }, configuredFetch, directFetch }).dispatch(alert());
+    expect(configuredFetch).toHaveBeenCalledOnce();
+    expect(directFetch).toHaveBeenCalledOnce();
+  });
+
+  it('retries transient failures with bounded backoff but not terminal 4xx', async () => {
+    const fetch = vi.fn().mockResolvedValueOnce(response(503)).mockResolvedValueOnce(response(200));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = new AlertDispatcher([spec({ maxAttempts: 3 })], { environment: { SLACK_WEBHOOK_URL: secretUrl() }, configuredFetch: fetch, sleep });
+    await expect(dispatcher.dispatch(alert())).resolves.toEqual([{ destinationId: 'slack', provider: 'slack', delivered: true, attempts: 2, status: 200 }]);
+    expect(sleep).toHaveBeenCalledWith(250);
+
+    const terminal = vi.fn().mockResolvedValue(response(400));
+    const result = await new AlertDispatcher([spec()], { environment: { SLACK_WEBHOOK_URL: secretUrl() }, configuredFetch: terminal }).dispatch(alert());
+    expect(result[0]).toMatchObject({ delivered: false, attempts: 1, status: 400, error: 'http-error' });
+  });
+
+  it('enforces per-destination rate limits without sleeping or mutating callers', async () => {
+    const fetch = vi.fn().mockResolvedValue(response());
+    const input = alert();
+    const dispatcher = new AlertDispatcher([spec({ rateLimitMs: 1000 })], { environment: { SLACK_WEBHOOK_URL: secretUrl() }, configuredFetch: fetch, now: () => 5000 });
+    await dispatcher.dispatch(input);
+    const second = await dispatcher.dispatch(input);
+    expect(second[0]).toMatchObject({ delivered: false, attempts: 0, error: 'rate-limited' });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(input.details).toBe('Evidence observed');
+  });
+
+  it('classifies timeout/network errors without leaking provider messages or URLs', async () => {
+    vi.useFakeTimers();
+    const fetch = vi.fn((_url: string, init: RequestInit) => new Promise<Response>((_resolve, reject) => init.signal?.addEventListener('abort', () => reject(Object.assign(new Error('secret URL leaked'), { name: 'AbortError' })), { once: true })));
+    const promise = new AlertDispatcher([spec({ timeoutMs: 100, maxAttempts: 1 })], { environment: { SLACK_WEBHOOK_URL: secretUrl() }, configuredFetch: fetch }).dispatch(alert());
+    await vi.advanceTimersByTimeAsync(100);
+    expect(await promise).toEqual([{ destinationId: 'slack', provider: 'slack', delivered: false, attempts: 1, error: 'timeout' }]);
+    vi.useRealTimers();
+  });
+
+  it('maps honeytoken events without exposing destination credentials', async () => {
+    const fetch = vi.fn().mockResolvedValue(response());
+    const dispatcher = new AlertDispatcher([spec()], { environment: { SLACK_WEBHOOK_URL: secretUrl() }, configuredFetch: fetch });
+    await expect(dispatcher.deliver({ id: 'event-1', tokenId: 'token-id', at: 1_800_000_000_000, nonceHash: 'nonce-hash', sourceHash: 'source-hash', classification: 'pending', provenance: 'authenticated-honeytoken-use' })).resolves.toBeUndefined();
+    expect(fetch.mock.calls[0][1].body).toContain('event-1');
+  });
+
+  it('contains no CORS override or dotenv loading surface', () => {
+    const source = readFileSync(new URL('../integrations/alerts.ts', import.meta.url), 'utf8');
+    expect(source).not.toMatch(/cors|dotenv|process\.cwd|api\/config\/env/);
+    expect(source).toContain("envKey: 'SLACK_WEBHOOK_URL' | 'DISCORD_WEBHOOK_URL' | 'SIEM_WEBHOOK_URL'");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1647,4 +1647,5 @@ export * from './threat-intel/correlation.js';
 export * from './llm/tool-call-boundary.js';
 export * from './evidence/retest.js';
 export * from './deception/honeytokens.js';
+export * from './integrations/alerts.js';
 export * from './llm/context-compression.js';

--- a/src/integrations/alerts.ts
+++ b/src/integrations/alerts.ts
@@ -1,0 +1,156 @@
+import { directFetch } from '../net/proxy.js';
+import { redactSecrets } from '../redact.js';
+import type { HoneytokenAlertSink, HoneytokenTrigger } from '../deception/honeytokens.js';
+
+export type AlertProvider = 'slack' | 'discord' | 'siem';
+export type AlertProxyPolicy = 'configured' | 'direct';
+export interface AlertDestinationSpec {
+  id: string;
+  provider: AlertProvider;
+  envKey: 'SLACK_WEBHOOK_URL' | 'DISCORD_WEBHOOK_URL' | 'SIEM_WEBHOOK_URL';
+  allowedHosts: readonly string[];
+  proxyPolicy: AlertProxyPolicy;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  rateLimitMs?: number;
+  maxPayloadBytes?: number;
+}
+export interface SecurityAlert {
+  event: string;
+  title: string;
+  details: string;
+  occurredAt: number;
+  severity?: 'critical' | 'high' | 'medium' | 'low' | 'info';
+  target?: string;
+  metadata?: Record<string, unknown>;
+}
+export interface AlertReceipt {
+  destinationId: string;
+  provider: AlertProvider;
+  delivered: boolean;
+  attempts: number;
+  status?: number;
+  error?: 'not-configured' | 'rate-limited' | 'payload-too-large' | 'timeout' | 'network' | 'http-error';
+}
+
+type Fetcher = (input: string, init: RequestInit) => Promise<Response>;
+interface Destination { spec: Required<Omit<AlertDestinationSpec, 'allowedHosts'>> & { allowedHosts: readonly string[] }; url?: URL }
+export interface AlertDispatcherOptions {
+  environment?: Readonly<Record<string, string | undefined>>;
+  configuredFetch?: Fetcher;
+  directFetch?: Fetcher;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+function resolvedSpec(spec: AlertDestinationSpec): Destination['spec'] {
+  if (!/^[a-zA-Z0-9_-]{1,64}$/.test(spec.id)) throw new Error('Alert destination id is invalid');
+  if (!spec.allowedHosts.length) throw new Error(`Alert destination ${spec.id} requires an allowlist`);
+  return {
+    ...spec,
+    timeoutMs: Math.min(60_000, Math.max(100, spec.timeoutMs ?? 10_000)),
+    maxAttempts: Math.min(5, Math.max(1, spec.maxAttempts ?? 3)),
+    rateLimitMs: Math.min(60_000, Math.max(0, spec.rateLimitMs ?? 1_000)),
+    maxPayloadBytes: Math.min(256 * 1024, Math.max(1_024, spec.maxPayloadBytes ?? 32 * 1024)),
+  };
+}
+
+function resolveDestination(spec: Destination['spec'], environment: Readonly<Record<string, string | undefined>>): URL | undefined {
+  const value = environment[spec.envKey];
+  if (!value) return undefined;
+  let url: URL;
+  try { url = new URL(value); } catch { throw new Error(`Alert destination ${spec.id} has an invalid environment URL`); }
+  if (url.protocol !== 'https:' || url.username || url.password || url.hash) throw new Error(`Alert destination ${spec.id} must use credential-free HTTPS URL syntax`);
+  const host = url.hostname.toLowerCase();
+  if (!spec.allowedHosts.some((allowed) => host === allowed.toLowerCase())) throw new Error(`Alert destination ${spec.id} host is not allowlisted`);
+  return url;
+}
+
+function safeAlert(alert: SecurityAlert): SecurityAlert {
+  if (typeof alert.event !== 'string' || typeof alert.title !== 'string' || typeof alert.details !== 'string' || !alert.event.trim() || !alert.title.trim() || !alert.details.trim() || !Number.isFinite(alert.occurredAt) || Number.isNaN(new Date(alert.occurredAt).getTime())) throw new Error('Alert event, title, details, and occurredAt are required');
+  if (alert.severity !== undefined && !['critical', 'high', 'medium', 'low', 'info'].includes(alert.severity)) throw new Error('Alert severity is invalid');
+  if (alert.target !== undefined && typeof alert.target !== 'string') throw new Error('Alert target is invalid');
+  if (alert.metadata !== undefined && (typeof alert.metadata !== 'object' || alert.metadata === null || Array.isArray(alert.metadata))) throw new Error('Alert metadata is invalid');
+  return redactSecrets(alert) as SecurityAlert;
+}
+
+function providerPayload(provider: AlertProvider, alert: SecurityAlert): unknown {
+  if (provider === 'slack') return { text: `[T3MP3ST ${alert.severity ?? 'info'}] ${alert.title}\n${alert.details}`, ...(alert.target ? { blocks: [{ type: 'section', text: { type: 'mrkdwn', text: `*Target:* ${alert.target}` } }] } : {}) };
+  if (provider === 'discord') return { username: 'T3MP3ST', embeds: [{ title: alert.title, description: alert.details, fields: [...(alert.target ? [{ name: 'Target', value: alert.target }] : []), { name: 'Severity', value: alert.severity ?? 'info' }], timestamp: new Date(alert.occurredAt).toISOString() }] };
+  return { source: 't3mp3st', event_type: alert.event, timestamp: new Date(alert.occurredAt).toISOString(), severity: alert.severity ?? 'info', title: alert.title, description: alert.details, ...(alert.target ? { target: alert.target } : {}), ...(alert.metadata ? { metadata: alert.metadata } : {}) };
+}
+
+function retryableStatus(status: number): boolean { return status === 408 || status === 429 || status >= 500; }
+
+export class AlertDispatcher implements HoneytokenAlertSink {
+  private readonly destinations: Destination[];
+  private readonly lastDispatch = new Map<string, number>();
+  private readonly configuredFetch: Fetcher;
+  private readonly directFetcher: Fetcher;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => number;
+
+  constructor(specs: readonly AlertDestinationSpec[], options: AlertDispatcherOptions = {}) {
+    const environment = options.environment ?? process.env;
+    this.destinations = specs.map((input) => {
+      const spec = resolvedSpec(input);
+      return { spec, url: resolveDestination(spec, environment) };
+    });
+    this.configuredFetch = options.configuredFetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.directFetcher = options.directFetch ?? (directFetch as unknown as Fetcher);
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.now = options.now ?? Date.now;
+  }
+
+  async deliver(event: HoneytokenTrigger): Promise<void> {
+    const receipts = await this.dispatch({ event: 'honeytoken_triggered', title: 'Honeytoken trigger pending review', details: `Trigger ${event.id} requires classification.`, occurredAt: event.at, severity: 'high', metadata: { tokenId: event.tokenId, nonceHash: event.nonceHash, sourceHash: event.sourceHash, provenance: event.provenance } });
+    if (receipts.some((receipt) => !receipt.delivered && receipt.error !== 'not-configured')) throw new Error('One or more alert destinations failed');
+  }
+
+  async dispatch(input: SecurityAlert): Promise<AlertReceipt[]> {
+    const alert = safeAlert(input);
+    return Promise.all(this.destinations.map((destination) => this.send(destination, alert)));
+  }
+
+  listDestinations(): Array<{ id: string; provider: AlertProvider; configured: boolean; host?: string; proxyPolicy: AlertProxyPolicy }> {
+    return this.destinations.map(({ spec, url }) => ({ id: spec.id, provider: spec.provider, configured: Boolean(url), ...(url ? { host: url.hostname } : {}), proxyPolicy: spec.proxyPolicy }));
+  }
+
+  private async send(destination: Destination, alert: SecurityAlert): Promise<AlertReceipt> {
+    const { spec, url } = destination;
+    if (!url) return { destinationId: spec.id, provider: spec.provider, delivered: false, attempts: 0, error: 'not-configured' };
+    const body = JSON.stringify(providerPayload(spec.provider, alert));
+    if (Buffer.byteLength(body) > spec.maxPayloadBytes) return { destinationId: spec.id, provider: spec.provider, delivered: false, attempts: 0, error: 'payload-too-large' };
+    const elapsed = this.now() - (this.lastDispatch.get(spec.id) ?? -Infinity);
+    if (elapsed < spec.rateLimitMs) return { destinationId: spec.id, provider: spec.provider, delivered: false, attempts: 0, error: 'rate-limited' };
+    this.lastDispatch.set(spec.id, this.now());
+    const fetcher = spec.proxyPolicy === 'direct' ? this.directFetcher : this.configuredFetch;
+    let lastStatus: number | undefined;
+    let lastError: AlertReceipt['error'] = 'network';
+    let attemptsMade = 0;
+    for (let attempt = 1; attempt <= spec.maxAttempts; attempt++) {
+      attemptsMade = attempt;
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), spec.timeoutMs);
+      try {
+        const response = await fetcher(url.toString(), { method: 'POST', redirect: 'manual', signal: controller.signal, headers: { 'content-type': 'application/json', accept: 'application/json' }, body });
+        lastStatus = response.status;
+        if (response.ok) return { destinationId: spec.id, provider: spec.provider, delivered: true, attempts: attempt, status: response.status };
+        lastError = 'http-error';
+        if (!retryableStatus(response.status)) break;
+      } catch (error) {
+        lastError = controller.signal.aborted || (error instanceof Error && error.name === 'AbortError') ? 'timeout' : 'network';
+      } finally { clearTimeout(timer); }
+      if (attempt < spec.maxAttempts) await this.sleep(Math.min(10_000, 250 * (2 ** (attempt - 1))));
+    }
+    return { destinationId: spec.id, provider: spec.provider, delivered: false, attempts: attemptsMade, ...(lastStatus ? { status: lastStatus } : {}), error: lastError };
+  }
+}
+
+export function defaultAlertDestinations(siemAllowedHosts: readonly string[] = []): AlertDestinationSpec[] {
+  return [
+    { id: 'slack', provider: 'slack', envKey: 'SLACK_WEBHOOK_URL', allowedHosts: ['hooks.slack.com'], proxyPolicy: 'configured' },
+    { id: 'discord', provider: 'discord', envKey: 'DISCORD_WEBHOOK_URL', allowedHosts: ['discord.com', 'discordapp.com'], proxyPolicy: 'configured' },
+    ...(siemAllowedHosts.length ? [{ id: 'siem', provider: 'siem' as const, envKey: 'SIEM_WEBHOOK_URL' as const, allowedHosts: siemAllowedHosts, proxyPolicy: 'configured' as const }] : []),
+  ];
+}


### PR DESCRIPTION
## Summary

- add opt-in Slack, Discord, and generic SIEM webhook delivery
- keep destination secrets in fixed server-side environment keys and expose only secret-safe metadata/receipts
- enforce exact HTTPS host allowlists, explicit proxy routing, manual redirect handling, redaction, timeouts, bounded retries/backoff, rate limits, and payload limits
- document the precise outbound data contract and operational trust boundary

## Security boundary

This focused implementation incorporates the review guidance recorded from #164: it does not add `/api/config/env`, alter CORS behavior, reflect arbitrary origins, or load `.env` from a target working directory. SIEM delivery is omitted until an operator supplies an explicit exact-host allowlist. Provider response bodies and webhook URLs never enter receipts or thrown delivery errors.

## Verification

- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` — 81 files, 911 tests; changed executable lines 71/71 (100%)
- `npm run test:pr` — pass; 911 tests, TypeScript, lint, operations checks, and doctor (optional-tool/offline-health warnings only)
- `npm run verify-claims` — 27 passed, 0 failed
- `npx eslint src/integrations/alerts.ts src/__tests__/alerts.test.ts` — pass

Closes #176

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
