### PR TITLE
feat: add optional Supabase persistence

### DIFF
--- a/docs/SUPABASE_PERSISTENCE.md
+++ b/docs/SUPABASE_PERSISTENCE.md
@@ -1,0 +1,19 @@
+# Optional Supabase persistence
+
+Supabase is an opt-in remote mirror. T3MP3ST's local state remains canonical and is written first; an unavailable or rejected remote write is reported separately and cannot roll back or mutate local state. Default operation does not construct this adapter and requires no Supabase account.
+
+## Trust and credentials
+
+The server reads only `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`. The privileged service-role key must never be placed in browser code, API responses, logs, model context, or a target repository's `.env`; this adapter exposes only configured state and hostname. Browser-safe anonymous keys are intentionally unsupported because this is a server-side persistence path. Operators must pass an exact hostname allowlist, use HTTPS, and account for their configured network proxy outside this adapter.
+
+Apply the numbered files in `migrations/supabase/` with a privileged migration identity. The table enables row-level security and revokes `anon` and `authenticated`; the server service role is the sole intended data-plane identity. Every key is `(tenant_id, snapshot_id)`, and callers must derive `tenant_id` from authenticated server context rather than user-controlled request fields.
+
+## Data processing and lifecycle
+
+Outbound rows contain tenant ID, snapshot ID, snapshot schema version, save timestamp, and the redacted snapshot payload. Snapshots can include operational state, findings, evidence metadata, approvals, and memory records, so treat the table as confidential security-testing data. Secret-like fields are redacted before transmission, but operators remain responsible for classifying free text before enabling the mirror.
+
+Supabase is an external processor for hosted projects; review its region, subprocessors, backups, access logs, and contractual terms. Define retention in project policy and schedule deletion using `adapter.delete(tenantId, snapshotId)`. Deleting a row may not immediately remove provider backups; use the provider process for account/project erasure. The reversible down migration drops the entire table and is destructive, so export required records and obtain operator approval before applying it.
+
+## Failure contract
+
+Writes are bounded by HTTPS validation, exact-host authorization, a 512 KiB default payload limit, and a 10-second timeout. Redirects are not followed. Results expose only fixed failure categories and status codes, never response bodies, credentials, URLs, or payloads. Automatic retries are deliberately omitted to avoid duplicate load; callers may retry the idempotent tenant/snapshot upsert under their own bounded policy.

--- a/migrations/supabase/0001_create_t3mp3st_snapshots.down.sql
+++ b/migrations/supabase/0001_create_t3mp3st_snapshots.down.sql
@@ -1,0 +1,1 @@
+drop table if exists public.t3mp3st_snapshots;

--- a/migrations/supabase/0001_create_t3mp3st_snapshots.up.sql
+++ b/migrations/supabase/0001_create_t3mp3st_snapshots.up.sql
@@ -1,0 +1,11 @@
+create table if not exists public.t3mp3st_snapshots (
+  tenant_id text not null,
+  snapshot_id text not null,
+  schema_version text not null,
+  saved_at timestamptz not null,
+  payload jsonb not null,
+  primary key (tenant_id, snapshot_id)
+);
+
+alter table public.t3mp3st_snapshots enable row level security;
+revoke all on table public.t3mp3st_snapshots from anon, authenticated;

--- a/src/__tests__/supabase-persistence.test.ts
+++ b/src/__tests__/supabase-persistence.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { LocalFirstPersistence, SupabasePersistenceAdapter, type PersistenceSnapshot } from '../persistence/supabase.js';
+import { migratePersistence, SUPABASE_MIGRATIONS, type MigrationStore } from '../persistence/migrations.js';
+
+const snapshot = (overrides: Partial<PersistenceSnapshot> = {}): PersistenceSnapshot => ({ id: 'state-1', tenantId: 'tenant-1', schemaVersion: 't3mp3st_state/v1', savedAt: '2026-09-03T00:00:00.000Z', data: { findings: 2 }, ...overrides });
+const spec = { allowedHosts: ['project.supabase.co'], timeoutMs: 100, maxPayloadBytes: 1024 };
+const environment = { SUPABASE_URL: 'https://project.supabase.co', SUPABASE_SERVICE_ROLE_KEY: 'service-secret' };
+
+describe('Supabase persistence trust boundary', () => {
+  it('is optional and exposes no endpoint or credential when absent', async () => {
+    const adapter = new SupabasePersistenceAdapter(spec, { environment: {} });
+    expect(adapter.status()).toEqual({ configured: false });
+    expect(await adapter.save(snapshot())).toMatchObject({ stored: false, error: 'not-configured' });
+  });
+
+  it.each(['http://project.supabase.co', 'https://user:pass@project.supabase.co', 'https://attacker.example'])("rejects unsafe endpoint %s", (url) => {
+    expect(() => new SupabasePersistenceAdapter(spec, { environment: { ...environment, SUPABASE_URL: url } })).toThrow();
+  });
+
+  it('sends a tenant-scoped redacted upsert and does not expose response bodies', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response('private provider details', { status: 503 }));
+    const adapter = new SupabasePersistenceAdapter(spec, { environment, fetch: fetcher });
+    const result = await adapter.save(snapshot({ data: { token: 'do-not-send', safe: 'yes' } }));
+    expect(result).toEqual({ stored: false, backend: 'supabase', error: 'http-error', status: 503 });
+    const [url, init] = fetcher.mock.calls[0];
+    expect(url).toContain('/rest/v1/t3mp3st_snapshots?on_conflict=tenant_id,snapshot_id');
+    expect(init).toMatchObject({ method: 'POST', redirect: 'manual' });
+    expect(init.headers.apikey).toBe('service-secret');
+    expect(init.body).not.toContain('do-not-send');
+    expect(init.body).toContain('[redacted]');
+    expect(JSON.stringify(result)).not.toContain('private provider details');
+    expect(JSON.stringify(adapter.status())).not.toContain('service-secret');
+  });
+
+  it('enforces payload and identifier limits before network use', async () => {
+    const fetcher = vi.fn();
+    const adapter = new SupabasePersistenceAdapter(spec, { environment, fetch: fetcher });
+    await expect(adapter.save(snapshot({ data: { text: 'x'.repeat(2_000) } }))).resolves.toMatchObject({ error: 'payload-too-large' });
+    await expect(adapter.save(snapshot({ tenantId: '../escape' }))).resolves.toMatchObject({ error: 'invalid-snapshot' });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('supports tenant-scoped deletion without placing secrets in the URL', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    const adapter = new SupabasePersistenceAdapter(spec, { environment, fetch: fetcher });
+    await expect(adapter.delete('tenant-1', 'state-1')).resolves.toEqual({ stored: true, backend: 'supabase', status: 204 });
+    expect(fetcher.mock.calls[0][0]).toContain('tenant_id=eq.tenant-1&snapshot_id=eq.state-1');
+    expect(fetcher.mock.calls[0][0]).not.toContain('service-secret');
+  });
+});
+
+describe('local-first failure isolation', () => {
+  it('commits a defensive local copy before reporting a remote failure', async () => {
+    let localCopy: PersistenceSnapshot | undefined;
+    const local = { save: vi.fn(async (value: PersistenceSnapshot) => { localCopy = value; }) };
+    const remoteFetch = vi.fn().mockRejectedValue(new Error('service-secret provider detail'));
+    const coordinator = new LocalFirstPersistence(local, new SupabasePersistenceAdapter(spec, { environment, fetch: remoteFetch }));
+    const input = snapshot();
+    const result = await coordinator.save(input);
+    input.data.findings = 99;
+    expect(result).toEqual({ localStored: true, remote: { stored: false, backend: 'supabase', error: 'network' } });
+    expect(localCopy?.data).toEqual({ findings: 2 });
+  });
+});
+
+describe('versioned migration contract', () => {
+  const store = (applied: number[] = []) => {
+    const transactions: Array<{ statements: readonly string[]; version: number }> = [];
+    const value: MigrationStore = { appliedVersions: async () => applied, transaction: async (statements, version) => { transactions.push({ statements, version }); } };
+    return { value, transactions };
+  };
+
+  it('applies a clean database once and is idempotent for an existing database', async () => {
+    const clean = store();
+    await expect(migratePersistence(clean.value)).resolves.toEqual([1]);
+    expect(clean.transactions[0].statements[0]).toContain('enable row level security');
+    const existing = store([1]);
+    await expect(migratePersistence(existing.value)).resolves.toEqual([]);
+    expect(existing.transactions).toEqual([]);
+  });
+
+  it('rejects unknown migration history and publishes matching reversible SQL artifacts', async () => {
+    await expect(migratePersistence(store([99]).value)).rejects.toThrow('unknown');
+    const up = readFileSync('migrations/supabase/0001_create_t3mp3st_snapshots.up.sql', 'utf8');
+    const down = readFileSync('migrations/supabase/0001_create_t3mp3st_snapshots.down.sql', 'utf8');
+    expect(up.replace(/\s+/g, ' ').trim()).toBe(SUPABASE_MIGRATIONS[0].up.replace(/\s+/g, ' ').trim());
+    expect(down.trim()).toBe(SUPABASE_MIGRATIONS[0].down);
+  });
+
+  it('does not introduce browser config, CORS overrides, or cwd dotenv loading', () => {
+    const source = readFileSync('src/persistence/supabase.ts', 'utf8');
+    expect(source).not.toMatch(/anon[_-]?key|cors|process\.cwd|dotenv|api\/config\/env/i);
+    expect(source).toContain('SUPABASE_SERVICE_ROLE_KEY');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1648,4 +1648,6 @@ export * from './llm/tool-call-boundary.js';
 export * from './evidence/retest.js';
 export * from './deception/honeytokens.js';
 export * from './integrations/alerts.js';
+export * from './persistence/supabase.js';
+export * from './persistence/migrations.js';
 export * from './llm/context-compression.js';

--- a/src/persistence/migrations.ts
+++ b/src/persistence/migrations.ts
@@ -1,0 +1,41 @@
+export interface PersistenceMigration {
+  version: number;
+  name: string;
+  up: string;
+  down: string;
+}
+
+export interface MigrationStore {
+  appliedVersions(): Promise<readonly number[]>;
+  transaction(statements: readonly string[], version: number): Promise<void>;
+}
+
+export const SUPABASE_MIGRATIONS: readonly PersistenceMigration[] = [{
+  version: 1,
+  name: 'create_t3mp3st_snapshots',
+  up: `create table if not exists public.t3mp3st_snapshots (
+  tenant_id text not null,
+  snapshot_id text not null,
+  schema_version text not null,
+  saved_at timestamptz not null,
+  payload jsonb not null,
+  primary key (tenant_id, snapshot_id)
+);
+alter table public.t3mp3st_snapshots enable row level security;
+revoke all on table public.t3mp3st_snapshots from anon, authenticated;`,
+  down: 'drop table if exists public.t3mp3st_snapshots;',
+}];
+
+export async function migratePersistence(store: MigrationStore, target = SUPABASE_MIGRATIONS.at(-1)?.version ?? 0): Promise<number[]> {
+  const known = new Set(SUPABASE_MIGRATIONS.map(({ version }) => version));
+  const applied = [...await store.appliedVersions()].sort((a, b) => a - b);
+  if (applied.some((version) => !known.has(version))) throw new Error('Database contains an unknown persistence migration');
+  const executed: number[] = [];
+  for (const migration of SUPABASE_MIGRATIONS) {
+    if (migration.version <= target && !applied.includes(migration.version)) {
+      await store.transaction([migration.up], migration.version);
+      executed.push(migration.version);
+    }
+  }
+  return executed;
+}

--- a/src/persistence/supabase.ts
+++ b/src/persistence/supabase.ts
@@ -1,0 +1,108 @@
+import { redactSecrets } from '../redact.js';
+
+export interface PersistenceSnapshot {
+  id: string;
+  tenantId: string;
+  schemaVersion: string;
+  savedAt: string;
+  data: Record<string, unknown>;
+}
+
+export interface SupabasePersistenceSpec {
+  allowedHosts: readonly string[];
+  timeoutMs?: number;
+  maxPayloadBytes?: number;
+}
+
+export interface SupabasePersistenceOptions {
+  environment?: Readonly<Record<string, string | undefined>>;
+  fetch?: (input: string, init: RequestInit) => Promise<Response>;
+}
+
+export type PersistenceReceipt =
+  | { stored: true; backend: 'supabase'; status: number }
+  | { stored: false; backend: 'supabase'; error: 'not-configured' | 'invalid-snapshot' | 'payload-too-large' | 'timeout' | 'network' | 'http-error'; status?: number };
+
+interface ResolvedConfig {
+  endpoint: URL;
+  serviceKey: string;
+}
+
+function resolveConfig(spec: SupabasePersistenceSpec, environment: Readonly<Record<string, string | undefined>>): ResolvedConfig | undefined {
+  const endpointValue = environment.SUPABASE_URL;
+  const serviceKey = environment.SUPABASE_SERVICE_ROLE_KEY;
+  if (!endpointValue && !serviceKey) return undefined;
+  if (!endpointValue || !serviceKey) throw new Error('Supabase persistence requires both server environment values');
+  if (!spec.allowedHosts.length) throw new Error('Supabase persistence requires an exact hostname allowlist');
+  let endpoint: URL;
+  try { endpoint = new URL(endpointValue); } catch { throw new Error('Supabase persistence endpoint is invalid'); }
+  if (endpoint.protocol !== 'https:' || endpoint.username || endpoint.password || endpoint.hash || endpoint.search) throw new Error('Supabase persistence endpoint must use credential-free HTTPS URL syntax');
+  if (!spec.allowedHosts.some((host) => endpoint.hostname.toLowerCase() === host.toLowerCase())) throw new Error('Supabase persistence endpoint is not allowlisted');
+  return { endpoint, serviceKey };
+}
+
+function validSnapshot(snapshot: PersistenceSnapshot): boolean {
+  const savedAt = new Date(snapshot.savedAt);
+  return /^[a-zA-Z0-9_-]{1,128}$/.test(snapshot.id)
+    && /^[a-zA-Z0-9_-]{1,128}$/.test(snapshot.tenantId)
+    && /^[a-zA-Z0-9_./-]{1,64}$/.test(snapshot.schemaVersion)
+    && !Number.isNaN(savedAt.getTime())
+    && typeof snapshot.data === 'object' && snapshot.data !== null && !Array.isArray(snapshot.data);
+}
+
+export class SupabasePersistenceAdapter {
+  private readonly config?: ResolvedConfig;
+  private readonly fetcher: (input: string, init: RequestInit) => Promise<Response>;
+  private readonly timeoutMs: number;
+  private readonly maxPayloadBytes: number;
+
+  constructor(spec: SupabasePersistenceSpec, options: SupabasePersistenceOptions = {}) {
+    this.config = resolveConfig(spec, options.environment ?? process.env);
+    this.fetcher = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.timeoutMs = Math.min(60_000, Math.max(100, spec.timeoutMs ?? 10_000));
+    this.maxPayloadBytes = Math.min(2 * 1024 * 1024, Math.max(1_024, spec.maxPayloadBytes ?? 512 * 1024));
+  }
+
+  status(): { configured: boolean; host?: string } {
+    return this.config ? { configured: true, host: this.config.endpoint.hostname } : { configured: false };
+  }
+
+  async save(snapshot: PersistenceSnapshot): Promise<PersistenceReceipt> {
+    if (!this.config) return { stored: false, backend: 'supabase', error: 'not-configured' };
+    if (!validSnapshot(snapshot)) return { stored: false, backend: 'supabase', error: 'invalid-snapshot' };
+    const body = JSON.stringify({ tenant_id: snapshot.tenantId, snapshot_id: snapshot.id, schema_version: snapshot.schemaVersion, saved_at: snapshot.savedAt, payload: redactSecrets(snapshot.data) });
+    if (Buffer.byteLength(body) > this.maxPayloadBytes) return { stored: false, backend: 'supabase', error: 'payload-too-large' };
+    return this.request('POST', 't3mp3st_snapshots?on_conflict=tenant_id,snapshot_id', body, { Prefer: 'resolution=merge-duplicates,return=minimal' });
+  }
+
+  async delete(tenantId: string, snapshotId: string): Promise<PersistenceReceipt> {
+    if (!this.config) return { stored: false, backend: 'supabase', error: 'not-configured' };
+    if (!/^[a-zA-Z0-9_-]{1,128}$/.test(tenantId) || !/^[a-zA-Z0-9_-]{1,128}$/.test(snapshotId)) return { stored: false, backend: 'supabase', error: 'invalid-snapshot' };
+    const query = `t3mp3st_snapshots?tenant_id=eq.${encodeURIComponent(tenantId)}&snapshot_id=eq.${encodeURIComponent(snapshotId)}`;
+    return this.request('DELETE', query, undefined, { Prefer: 'return=minimal' });
+  }
+
+  private async request(method: 'POST' | 'DELETE', relative: string, body?: string, extraHeaders: Record<string, string> = {}): Promise<PersistenceReceipt> {
+    if (!this.config) return { stored: false, backend: 'supabase', error: 'not-configured' };
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const url = new URL(`/rest/v1/${relative}`, this.config.endpoint);
+      const response = await this.fetcher(url.toString(), { method, redirect: 'manual', signal: controller.signal, headers: { apikey: this.config.serviceKey, authorization: `Bearer ${this.config.serviceKey}`, 'content-type': 'application/json', ...extraHeaders }, ...(body ? { body } : {}) });
+      if (response.ok) return { stored: true, backend: 'supabase', status: response.status };
+      return { stored: false, backend: 'supabase', error: 'http-error', status: response.status };
+    } catch (error) {
+      return { stored: false, backend: 'supabase', error: controller.signal.aborted || (error instanceof Error && error.name === 'AbortError') ? 'timeout' : 'network' };
+    } finally { clearTimeout(timer); }
+  }
+}
+
+export interface LocalSnapshotStore { save(snapshot: PersistenceSnapshot): Promise<void> }
+export class LocalFirstPersistence {
+  constructor(private readonly local: LocalSnapshotStore, private readonly remote?: SupabasePersistenceAdapter) {}
+  async save(snapshot: PersistenceSnapshot): Promise<{ localStored: true; remote: PersistenceReceipt }> {
+    await this.local.save(structuredClone(snapshot));
+    const remote = this.remote ? await this.remote.save(structuredClone(snapshot)) : { stored: false as const, backend: 'supabase' as const, error: 'not-configured' as const };
+    return { localStored: true, remote };
+  }
+}


### PR DESCRIPTION
## Summary

- add an optional server-only Supabase snapshot mirror while keeping local state canonical
- enforce fixed environment credentials, exact-host HTTPS authorization, redaction, tenant-scoped atomic upserts/deletion, payload bounds, timeout, and secret-safe receipts
- add versioned reversible migration artifacts with RLS and public-role revocation
- document data classification, egress, tenancy, retention, deletion, backups, and processor responsibilities

## Verification

- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` — 82 files, 922 tests; 70/70 changed executable lines (100%)
- `npm run test:pr` — pass
- `npm run verify-claims` — 27 passed, 0 failed

Closes #183

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
