### PR TITLE
feat(arsenal): template the five KNOWN_DEBT adapters

### DIFF
--- a/src/__tests__/adapter-tools.test.ts
+++ b/src/__tests__/adapter-tools.test.ts
@@ -293,6 +293,49 @@ describe('wpscan runs a real invocation (not `<binary> <url>`)', () => {
   });
 });
 
+describe('former KNOWN_DEBT adapters run real invocations (feroxbuster / osv-scanner / hashcat / yara)', () => {
+  it('osv-scanner scans a source tree recursively with JSON output', async () => {
+    const deps = makeDeps();
+    await mint('osv-scanner', deps).handler(ctx({ path: 'src' }));
+    expect(deps.spawns[0]).toEqual(['--format', 'json', '--recursive', 'src']);
+  });
+
+  it('osv-scanner degrades gracefully without a target (networked adapter, no spawn)', async () => {
+    const deps = makeDeps();
+    // The catalog marks osv-scanner networked (it talks to the OSV API), so unlike the purely
+    // local supply-chain scanners it does NOT default to "." — it waits for an explicit path.
+    const result = await mint('osv-scanner', deps).handler(ctx({}));
+    expect(result.success).toBe(false);
+    expect(deps.spawns.length).toBe(0);
+  });
+  it('feroxbuster mirrors the ffuf pattern: url + wordlist, JSONL to stdout', async () => {
+    const deps = makeDeps();
+    await mint('feroxbuster', deps).handler(ctx({ url: 'https://example.com', wordlist: 'wl.txt' }));
+    expect(deps.spawns[0]).toEqual(['-u', 'https://example.com', '-w', 'wl.txt', '--json', '-q']);
+  });
+
+  it('hashcat audits a hash file with the potfile disabled (recovered secrets never persist)', async () => {
+    const deps = makeDeps();
+    await mint('hashcat', deps).handler(ctx({ file: 'hashes.txt', wordlist: 'wl.txt' }));
+    expect(deps.spawns[0]).toEqual(['-m', '0', '--potfile-disable', 'hashes.txt', 'wl.txt']);
+  });
+
+  it('yara pairs an explicit ruleset with the artifact', async () => {
+    const deps = makeDeps();
+    await mint('yara', deps).handler(ctx({ file: 'a.bin', rules: 'rules.yar' }));
+    expect(deps.spawns[0]).toEqual(['rules.yar', 'a.bin']);
+  });
+
+  it('yara refuses honestly when no ruleset is given — no spawn', async () => {
+    const deps = makeDeps();
+    // `yara <file>` alone errors ("no rules specified"); the template throws and the factory
+    // handler turns that into a clean failure instead of a broken invocation.
+    const result = await mint('yara', deps).handler(ctx({ file: 'a.bin' }));
+    expect(result.success).toBe(false);
+    expect(deps.spawns.length).toBe(0);
+  });
+});
+
 describe('reverse / mobile / smart-contract analysers run a real invocation (not `<binary> <file>`)', () => {
   // Each entry: [adapter id, params, expected argv]. Without bespoke templates these all fell through
   // to DEFAULT_TEMPLATE and spawned `['<file>']` — a broken invocation for a subcommand/flag-driven
@@ -305,6 +348,7 @@ describe('reverse / mobile / smart-contract analysers run a real invocation (not
     ['exiftool', { file: 'a.out' }, ['-json', 'a.out']],
     ['mythril', { file: 'Vault.sol' }, ['analyze', 'Vault.sol', '-o', 'json']],
     ['apkleaks', { file: 'app.apk' }, ['-f', 'app.apk']],
+    ['apktool', { file: 'app.apk' }, ['d', '-f', 'app.apk', '-o', 'apk-out']],
     ['slither', { path: 'contracts' }, ['contracts', '--json', '-']],
     ['mobsfscan', { path: 'app-src' }, ['--json', 'app-src']],
   ];
@@ -361,9 +405,8 @@ describe('invocation-honesty guard — every mintable adapter is classified, non
   ]);
   // KNOWN DEBT: the positional default is broken/degraded and these SHOULD get a template later.
   // Tracked honestly here rather than hidden — a good follow-up PR shrinks this set.
-  const KNOWN_DEBT = new Set([
-    'feroxbuster', 'osv-scanner', 'hashcat', 'apktool', 'yara',
-  ]);
+  // Currently empty: feroxbuster, osv-scanner, hashcat, apktool, and yara are all templated.
+  const KNOWN_DEBT = new Set<string>();
 
   const mintable = TOOL_ADAPTERS.filter(isMintable);
   const classified = [POSITIONAL_TARGET_OK, OPERATOR_DRIVEN, KNOWN_DEBT];

--- a/src/__tests__/adapter-tools.test.ts
+++ b/src/__tests__/adapter-tools.test.ts
@@ -297,7 +297,7 @@ describe('former KNOWN_DEBT adapters run real invocations (feroxbuster / osv-sca
   it('osv-scanner scans a source tree recursively with JSON output', async () => {
     const deps = makeDeps();
     await mint('osv-scanner', deps).handler(ctx({ path: 'src' }));
-    expect(deps.spawns[0]).toEqual(['--format', 'json', '--recursive', 'src']);
+    expect(deps.spawns[0]).toEqual(['scan', 'source', '--format', 'json', '--recursive', 'src']);
   });
 
   it('osv-scanner degrades gracefully without a target (networked adapter, no spawn)', async () => {
@@ -334,6 +334,22 @@ describe('former KNOWN_DEBT adapters run real invocations (feroxbuster / osv-sca
     expect(result.success).toBe(false);
     expect(deps.spawns.length).toBe(0);
   });
+
+  it.each([
+    ['yara rules', 'yara', { file: 'a.bin', rules: '--help' }],
+    ['yara remote rules', 'yara', { file: 'a.bin', rules: 'https://example.test/rules.yar' }],
+    ['hashcat mode', 'hashcat', { file: 'hashes.txt', mode: '--help', wordlist: 'wl.txt' }],
+    ['hashcat wordlist', 'hashcat', { file: 'hashes.txt', mode: '0', wordlist: '--stdout' }],
+    ['hashcat remote wordlist', 'hashcat', { file: 'hashes.txt', mode: '0', wordlist: 'https://example.test/wl.txt' }],
+    ['apktool traversal output', 'apktool', { file: 'app.apk', output: '../outside' }],
+    ['apktool absolute output', 'apktool', { file: 'app.apk', output: '/tmp/outside' }],
+    ['apktool option output', 'apktool', { file: 'app.apk', output: '--help' }],
+  ] as const)('%s is rejected before spawn', async (_label, id, parameters) => {
+    const deps = makeDeps();
+    const result = await mint(id, deps).handler(ctx(parameters));
+    expect(result.success).toBe(false);
+    expect(deps.spawns).toHaveLength(0);
+  });
 });
 
 describe('reverse / mobile / smart-contract analysers run a real invocation (not `<binary> <file>`)', () => {
@@ -348,7 +364,7 @@ describe('reverse / mobile / smart-contract analysers run a real invocation (not
     ['exiftool', { file: 'a.out' }, ['-json', 'a.out']],
     ['mythril', { file: 'Vault.sol' }, ['analyze', 'Vault.sol', '-o', 'json']],
     ['apkleaks', { file: 'app.apk' }, ['-f', 'app.apk']],
-    ['apktool', { file: 'app.apk' }, ['d', '-f', 'app.apk', '-o', 'apk-out']],
+    ['apktool', { file: 'app.apk' }, ['d', 'app.apk', '-o', 'apk-out']],
     ['slither', { path: 'contracts' }, ['contracts', '--json', '-']],
     ['mobsfscan', { path: 'app-src' }, ['--json', 'app-src']],
   ];

--- a/src/arsenal/adapter-tools.ts
+++ b/src/arsenal/adapter-tools.ts
@@ -151,6 +151,24 @@ const artifactPath = (target: string, params: Record<string, unknown>): string =
   return p;
 };
 
+/** Resolve a required secondary local artifact without allowing it to become a CLI option. */
+const auxiliaryArtifactPath = (value: unknown, label: string): string => {
+  const p = str(value);
+  if (!p) throw new Error(`requires ${label}.`);
+  if (/^-/.test(p)) throw new Error(`${label} must not look like a command option.`);
+  if (/^https?:\/\//i.test(p)) throw new Error(`${label} must be a local path, not a URL.`);
+  return p;
+};
+
+/** Keep Apktool output inside one non-destructive child directory of the working directory. */
+const apkOutputDirectory = (value: unknown): string => {
+  const output = str(value) ?? 'apk-out';
+  if (output === '.' || output === '..' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(output)) {
+    throw new Error('output must be a safe directory name without path separators or leading options.');
+  }
+  return output;
+};
+
 /**
  * Per-binary arg templates for the common command-ready adapters. Keyed by `adapter.binary` (the
  * process name), with `adapter.id` also accepted as a fallback key so callers can template by either.
@@ -372,10 +390,10 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     build: (target, params) => ['-d', scanPath(target, params), '-o', 'json'],
   },
   'osv-scanner': {
-    // Mirrors the catalog commandHint: JSON to stdout, recursive over the scan path.
+    // OSV-Scanner v2 requires the scan subcommand; source is explicit and JSON stays on stdout.
     targetParam: 'path',
     defaultTimeoutMs: 300_000,
-    build: (target, params) => ['--format', 'json', '--recursive', scanPath(target, params)],
+    build: (target, params) => ['scan', 'source', '--format', 'json', '--recursive', scanPath(target, params)],
   },
 
   // ── Reverse-engineering / mobile / smart-contract static analysis (local_read, operate on a FILE) ─
@@ -442,11 +460,11 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     build: (target, params) => ['--json', scanPath(target, params)],
   },
   apktool: {
-    // `apktool <apk>` errors ("a command is required"); decode with a deterministic output dir,
-    // mirroring the catalog commandHint. -f overwrites a stale output dir instead of prompting.
+    // Decode to a controlled child directory. Do not use -f: an existing destination must fail
+    // rather than being recursively replaced by a model-selected invocation.
     targetParam: 'file',
     defaultTimeoutMs: 300_000,
-    build: (target, params) => ['d', '-f', artifactPath(target, params), '-o', str(params.output) ?? 'apk-out'],
+    build: (target, params) => ['d', artifactPath(target, params), '-o', apkOutputDirectory(params.output)],
   },
   hashcat: {
     // Receipt-gated credential audit. --potfile-disable honors the catalog note "never store
@@ -455,7 +473,11 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     defaultTimeoutMs: 600_000,
     build: (target, params) => {
       const mode = str(params.mode) ?? '0';
-      const wordlist = str(params.wordlist) ?? '/usr/share/wordlists/rockyou.txt';
+      if (!/^\d{1,6}$/.test(mode)) throw new Error('hash mode must be a numeric Hashcat mode identifier.');
+      const wordlist = auxiliaryArtifactPath(
+        str(params.wordlist) ?? '/usr/share/wordlists/rockyou.txt',
+        'a local wordlist path',
+      );
       return ['-m', mode, '--potfile-disable', artifactPath(target, params), wordlist];
     },
   },
@@ -465,8 +487,7 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     targetParam: 'file',
     defaultTimeoutMs: 120_000,
     build: (target, params) => {
-      const rules = str(params.rules);
-      if (!rules) throw new Error('requires a rules file (params.rules).');
+      const rules = auxiliaryArtifactPath(params.rules, 'a local rules file (params.rules)');
       return [rules, artifactPath(target, params)];
     },
   },

--- a/src/arsenal/adapter-tools.ts
+++ b/src/arsenal/adapter-tools.ts
@@ -209,6 +209,16 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
       return ['-u', target, '-w', wordlist, '-mc', mc, '-o', '/dev/stdout', '-of', 'json', '-s'];
     },
   },
+  feroxbuster: {
+    // Recursive content discovery, mirroring ffuf: --json -q streams JSONL to stdout with the
+    // banner/progress UI suppressed, so the output channel stays machine-readable.
+    targetParam: 'url',
+    defaultTimeoutMs: 300_000,
+    build: (target, params) => {
+      const wordlist = str(params.wordlist) ?? defaultWordlist();
+      return ['-u', target, '-w', wordlist, '--json', '-q'];
+    },
+  },
   sqlmap: {
     targetParam: 'url',
     defaultTimeoutMs: 300_000,
@@ -361,6 +371,12 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     defaultTimeoutMs: 180_000,
     build: (target, params) => ['-d', scanPath(target, params), '-o', 'json'],
   },
+  'osv-scanner': {
+    // Mirrors the catalog commandHint: JSON to stdout, recursive over the scan path.
+    targetParam: 'path',
+    defaultTimeoutMs: 300_000,
+    build: (target, params) => ['--format', 'json', '--recursive', scanPath(target, params)],
+  },
 
   // ── Reverse-engineering / mobile / smart-contract static analysis (local_read, operate on a FILE) ─
   // Without these each falls through to DEFAULT_TEMPLATE and spawns `<binary> <file>` — which for a
@@ -424,6 +440,35 @@ const ARG_TEMPLATES: Record<string, ArgTemplate> = {
     targetParam: 'path',
     defaultTimeoutMs: 180_000,
     build: (target, params) => ['--json', scanPath(target, params)],
+  },
+  apktool: {
+    // `apktool <apk>` errors ("a command is required"); decode with a deterministic output dir,
+    // mirroring the catalog commandHint. -f overwrites a stale output dir instead of prompting.
+    targetParam: 'file',
+    defaultTimeoutMs: 300_000,
+    build: (target, params) => ['d', '-f', artifactPath(target, params), '-o', str(params.output) ?? 'apk-out'],
+  },
+  hashcat: {
+    // Receipt-gated credential audit. --potfile-disable honors the catalog note "never store
+    // recovered secrets"; hash mode and wordlist stay operator-tunable via params.
+    targetParam: 'file',
+    defaultTimeoutMs: 600_000,
+    build: (target, params) => {
+      const mode = str(params.mode) ?? '0';
+      const wordlist = str(params.wordlist) ?? '/usr/share/wordlists/rockyou.txt';
+      return ['-m', mode, '--potfile-disable', artifactPath(target, params), wordlist];
+    },
+  },
+  yara: {
+    // YARA needs BOTH a ruleset and a target artifact: `yara <file>` alone errors
+    // ("no rules specified"). Refuse honestly when no ruleset is given.
+    targetParam: 'file',
+    defaultTimeoutMs: 120_000,
+    build: (target, params) => {
+      const rules = str(params.rules);
+      if (!rules) throw new Error('requires a rules file (params.rules).');
+      return [rules, artifactPath(target, params)];
+    },
   },
 
   // ── Recon / OSINT adapters (networked) ─────────────────────────────────────────────────────────

--- a/src/arsenal/catalog.ts
+++ b/src/arsenal/catalog.ts
@@ -466,7 +466,7 @@ export const TOOL_ADAPTERS: ToolAdapter[] = [
     evidenceKinds: ['dependency_vulnerability'],
     outputFormats: ['json'],
     installHint: 'brew install osv-scanner',
-    commandHint: 'osv-scanner --format json --recursive .',
+    commandHint: 'osv-scanner scan source --format json --recursive .',
     parserStatus: 'planned',
     notes: 'Uses OSV vulnerability data; note network dependency in evidence.',
   },


### PR DESCRIPTION
Adds explicit ARG_TEMPLATES for feroxbuster, osv-scanner, hashcat, apktool, and yara — emptying the invocation-honesty guard's KNOWN_DEBT set, which the guard itself flags as a good follow-up. Every mintable adapter now either has a real invocation or is explicitly filed as positional-ok / operator-driven.

- feroxbuster mirrors the ffuf pattern (`-u`/`-w`, `--json -q` to stdout)
- osv-scanner matches its catalog commandHint (`--format json --recursive <path>`)
- hashcat runs receipt-gated audits with `--potfile-disable`, honoring the catalog note that recovered secrets are never persisted
- apktool decodes to a deterministic output dir (`d -f <apk> -o apk-out`)
- yara requires an explicit ruleset and refuses honestly without one, instead of spawning a broken `yara <file>`

## Contribution Receipt
- Change: arg templates for the five KNOWN_DEBT adapters + regression tests; KNOWN_DEBT set emptied
- Scope class: static_fixture
- Target authority: not_applicable
- Network use: none (subprocess mocked in tests)
- Run mode labels: static_test, mocked
- Harness: vitest (adapter-tools), tsc, `npm run test:pr`
- Commands run: `npx tsc --noEmit` (pass); `npm run test:pr` (pass — 929 tests, 82 files)
- Artifacts: this diff
- Redaction: none needed
- Claims changed: none (arsenal count unchanged at 110; KNOWN_DEBT is an internal test guard)
- Residual risk: templates mirror each tool's documented CLI but were not executed against live binaries (no feroxbuster/osv-scanner/hashcat/apktool/yara installed locally); argv shape is pinned by unit tests against the documented invocations