### PR TITLE
feat(arsenal): parse WPScan JSON into structured findings

### DIFF
--- a/src/__tests__/fixtures/wpscan.json
+++ b/src/__tests__/fixtures/wpscan.json
@@ -1,0 +1,116 @@
+{
+  "banner": {
+    "description": "WordPress Security Scanner by the WPScan Team",
+    "version": "3.8.28"
+  },
+  "start_time": 1725400000,
+  "target_url": "https://target.example.com",
+  "target_ip": "192.0.2.10",
+  "effective_url": "https://target.example.com/",
+  "interesting_findings": [
+    {
+      "url": "https://target.example.com/xmlrpc.php",
+      "to_s": "XML-RPC seems to be enabled: https://target.example.com/xmlrpc.php",
+      "type": "xmlrpc",
+      "found_by": "Link Tag (Passive Detection)",
+      "confidence": 30,
+      "references": {
+        "url": ["http://codex.wordpress.org/XML-RPC_Pingback_API"]
+      },
+      "interesting_entries": []
+    },
+    {
+      "url": "https://target.example.com/readme.html",
+      "to_s": "WordPress readme file found",
+      "type": "readme",
+      "found_by": "Direct Access (Aggressive Detection)",
+      "confidence": 100,
+      "references": {},
+      "interesting_entries": []
+    }
+  ],
+  "version": {
+    "number": "6.4.2",
+    "release_date": "2023-12-06",
+    "status": "insecure",
+    "found_by": "Rss Generator (Passive Detection)",
+    "confidence": 100,
+    "interesting_entries": [],
+    "confirmed_by": {},
+    "vulnerabilities": [
+      {
+        "title": "WordPress Core - Fixture Vulnerability (test data)",
+        "fixed_in": "6.4.3",
+        "references": {
+          "url": ["https://wordpress.org/news/category/security/"],
+          "wpvulndb": ["00000"]
+        }
+      }
+    ]
+  },
+  "main_theme": {
+    "slug": "twentytwentyfour",
+    "location": "https://target.example.com/wp-content/themes/twentytwentyfour/",
+    "outdated": false,
+    "vulnerabilities": [],
+    "version": { "number": "1.0", "confidence": 80 }
+  },
+  "plugins": {
+    "woocommerce": {
+      "slug": "woocommerce",
+      "location": "https://target.example.com/wp-content/plugins/woocommerce/",
+      "latest_version": "4.5.0",
+      "outdated": true,
+      "vulnerabilities": [
+        {
+          "title": "WooCommerce < 4.1.0 - Unescaped Metadata when Duplicating Products",
+          "fixed_in": "4.1.0",
+          "references": {
+            "url": ["https://plugins.trac.wordpress.org/browser/woocommerce/tags/4.1.0/readme.txt?rev=2298743"],
+            "wpvulndb": ["10220"]
+          }
+        },
+        {
+          "title": "WooCommerce < 4.2.1 - Potential Cross-Site Scripting (XSS) via SelectWoo",
+          "fixed_in": "4.2.1",
+          "references": {
+            "url": ["https://woocommerce.wordpress.com/2020/06/22/woocommerce-4-2-1-security-and-fix-release/"],
+            "wpvulndb": ["10282"]
+          }
+        }
+      ],
+      "version": { "number": "3.9.2", "confidence": 100 }
+    },
+    "contact-form-7-datepicker": {
+      "slug": "contact-form-7-datepicker",
+      "location": "https://target.example.com/wp-content/plugins/contact-form-7-datepicker/",
+      "latest_version": "2.6.0",
+      "outdated": false,
+      "vulnerabilities": [
+        {
+          "title": "Contact Form 7 Datepicker <= 2.6.0 - Authenticated Stored Cross-Site Scripting (XSS)",
+          "fixed_in": null,
+          "references": {
+            "cve": ["2020-11516"],
+            "url": ["https://www.wordfence.com/blog/2020/04/high-severity-vulnerability-leads-to-closure-of-plugin-with-over-100000-installations/"],
+            "wpvulndb": ["10164"]
+          }
+        }
+      ],
+      "version": null
+    },
+    "akismet": {
+      "slug": "akismet",
+      "location": "https://target.example.com/wp-content/plugins/akismet/",
+      "outdated": false,
+      "vulnerabilities": [],
+      "version": null
+    }
+  },
+  "users": {
+    "admin": { "id": 1, "confidence": 100 },
+    "editor": { "id": 2, "confidence": 100 }
+  },
+  "scan_aborted": false,
+  "requests_done": 42
+}

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -69,6 +69,29 @@ describe('parseToolOutput — field mapping per scanner', () => {
     expect(f[0].title).toBe('katana: 3 endpoint(s) discovered');
     expect(f[0].details).toContain('/about');
   });
+
+  it('wpscan: core/plugin vulns + interesting findings + enumerated users, severity documented', () => {
+    const f = parseToolOutput('wpscan', fixture('wpscan.json'));
+    expect(f).toHaveLength(7); // 1 core + 3 plugin vulns, 2 interesting findings, 1 users aggregate
+    const core = f[0];
+    expect(core.title).toContain('WordPress core 6.4.2');
+    expect(core.severity).toBe('high'); // wpscan labels this core 'insecure'
+    expect(core.remediation).toBe('update WordPress core 6.4.2 to 6.4.3');
+    const woo = f.filter((x) => x.title.startsWith('plugin woocommerce'));
+    expect(woo).toHaveLength(2);
+    expect(woo[0].severity).toBe('medium'); // confirmed component vuln; wpscan never scores severity
+    expect(woo[0].remediation).toBe('update plugin woocommerce to 4.1.0');
+    const cf7 = f.find((x) => x.title.includes('contact-form-7-datepicker'));
+    expect(cf7?.cve).toEqual(['CVE-2020-11516']); // bare wpvulndb cve ref gains the CVE- prefix
+    expect(cf7?.remediation).toBeUndefined(); // fixed_in: null → no fabricated fix
+    const xmlrpc = f.find((x) => x.title.includes('XML-RPC'));
+    expect(xmlrpc?.severity).toBe('info');
+    expect(xmlrpc?.details).toContain('confidence: 30');
+    const users = f.find((x) => x.title.includes('user(s) enumerated'));
+    expect(users?.title).toBe('wpscan: 2 user(s) enumerated');
+    expect(users?.details).toContain('admin');
+    expect(users?.details).toContain('editor');
+  });
 });
 
 describe('parseToolOutput — honesty contract (never fabricate, never throw)', () => {
@@ -104,7 +127,7 @@ describe('parseToolOutput — honesty contract (never fabricate, never throw)', 
 
   it('exposes exactly the wired parser ids', () => {
     expect([...PARSED_TOOL_IDS].sort()).toEqual(
-      ['arjun', 'dalfox', 'feroxbuster', 'ffuf', 'garak', 'gitleaks', 'grype', 'httpx', 'katana', 'nuclei', 'semgrep', 'sqlmap', 'trivy', 'trufflehog', 'wafw00f'],
+      ['arjun', 'dalfox', 'feroxbuster', 'ffuf', 'garak', 'gitleaks', 'grype', 'httpx', 'katana', 'nuclei', 'semgrep', 'sqlmap', 'trivy', 'trufflehog', 'wafw00f', 'wpscan'],
     );
   });
 

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -92,6 +92,38 @@ describe('parseToolOutput — field mapping per scanner', () => {
     expect(users?.details).toContain('admin');
     expect(users?.details).toContain('editor');
   });
+
+  it('wpscan: redacts target-derived secrets from every emitted field', () => {
+    const secret = 'wpscan-secret-value';
+    const f = parseToolOutput('wpscan', JSON.stringify({
+      interesting_findings: [{
+        to_s: `Authenticated endpoint https://operator:${secret}@target.test/?token=${secret}`,
+        url: `https://operator:${secret}@target.test/?token=${secret}`,
+        found_by: `token=${secret}`,
+      }],
+      users: { [`token=${secret}`]: {} },
+    }));
+    const serialized = JSON.stringify(f);
+    expect(f).toHaveLength(2);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain('operator:');
+    expect(serialized).toContain('[redacted]');
+  });
+
+  it('wpscan: normalizes valid CVEs and discards malformed references', () => {
+    const f = parseToolOutput('wpscan', JSON.stringify({
+      plugins: {
+        example: {
+          vulnerabilities: [{
+            title: 'Mixed reference quality',
+            references: { cve: ['2020-11516', 'cve-2021-44228', 'not-a-cve', '2024-12'] },
+          }],
+        },
+      },
+    }));
+    expect(f).toHaveLength(1);
+    expect(f[0].cve).toEqual(['CVE-2020-11516', 'CVE-2021-44228']);
+  });
 });
 
 describe('parseToolOutput — honesty contract (never fabricate, never throw)', () => {

--- a/src/arsenal/catalog.ts
+++ b/src/arsenal/catalog.ts
@@ -323,7 +323,7 @@ export const TOOL_ADAPTERS: ToolAdapter[] = [
     outputFormats: ['json', 'text'],
     installHint: 'brew install wpscanteam/tap/wpscan  # or: gem install wpscan',
     commandHint: 'wpscan --url https://example.com --format json',
-    parserStatus: 'planned',
+    parserStatus: 'structured',
     notes: 'WordPress CMS, plugin, and theme enumeration; validate findings before reporting.',
   },
   {

--- a/src/arsenal/parsers.ts
+++ b/src/arsenal/parsers.ts
@@ -547,15 +547,18 @@ function parseWpscan(raw: string): ToolFinding[] {
     if (!Array.isArray(vulns)) return;
     for (const item of vulns) {
       const v = asObj(item);
-      const title = String(v.title ?? '');
+      const title = redactString(String(v.title ?? ''));
       if (!title) continue;
       const refs = asObj(v.references);
       const f: ToolFinding = {
-        title: `${component}: ${title}`,
+        title: redactString(`${component}: ${title}`),
         severity,
-        details: truncate(asStrArray(refs.url).join(' ') || title),
+        details: truncate(redactString(asStrArray(refs.url).join(' ') || title)),
       };
-      const cves = asStrArray(refs.cve).map((c) => (/^CVE-/i.test(c) ? c : `CVE-${c}`));
+      const cves = asStrArray(refs.cve)
+        .map((c) => c.trim().toUpperCase())
+        .map((c) => (c.startsWith('CVE-') ? c : `CVE-${c}`))
+        .filter((c) => /^CVE-\d{4}-\d{4,}$/.test(c));
       if (cves.length) f.cve = cves;
       const fixed = String(v.fixed_in ?? '');
       if (fixed) f.remediation = `update ${component} to ${fixed}`;
@@ -575,14 +578,14 @@ function parseWpscan(raw: string): ToolFinding[] {
   if (Array.isArray(interesting)) {
     for (const item of interesting) {
       const o = asObj(item);
-      const label = String(o.to_s ?? o.url ?? '');
+      const label = redactString(String(o.to_s ?? o.url ?? ''));
       if (!label) continue;
       out.push({
         title: `wpscan: ${truncate(label, 80)}`,
         severity: 'info',
         details: [
           o.url && `url: ${redactString(String(o.url))}`,
-          o.found_by && `found_by: ${String(o.found_by)}`,
+          o.found_by && `found_by: ${redactString(String(o.found_by))}`,
           o.confidence !== undefined && `confidence: ${String(o.confidence)}`,
         ].filter(Boolean).join(' | '),
       });
@@ -593,7 +596,7 @@ function parseWpscan(raw: string): ToolFinding[] {
     out.push({
       title: `wpscan: ${users.length} user(s) enumerated`,
       severity: 'info',
-      details: `Usernames: ${users.join(', ')} — valid account names for password-policy review, not proof of compromise.`,
+      details: `Usernames: ${redactString(users.join(', '))} — valid account names for password-policy review, not proof of compromise.`,
     });
   }
   return out;

--- a/src/arsenal/parsers.ts
+++ b/src/arsenal/parsers.ts
@@ -531,6 +531,74 @@ function parseArjun(raw: string): ToolFinding[] {
   return out;
 }
 
+// ── wpscan --format json : WP core/plugin/theme vulns + interesting findings ──────────────
+// WPScan emits ONE JSON document: { version, main_theme, plugins{}, themes{},
+// interesting_findings[], users{}, … } with vulns as { title, fixed_in, references:
+// { cve: ['2020-11516'], url: [...], wpvulndb: [...] } } — CVE refs arrive WITHOUT the
+// 'CVE-' prefix. WPScan never scores severity, so this mapping is documented, not invented:
+// core vulns on a core WPScan itself labels 'insecure' → high; other confirmed component
+// vulns → medium; enumeration / interesting findings → info.
+function parseWpscan(raw: string): ToolFinding[] {
+  const doc = asObj(jsonDoc(raw));
+  if (Object.keys(doc).length === 0) return [];
+  const out: ToolFinding[] = [];
+  const pushVulns = (component: string, node: unknown, severity: Severity) => {
+    const vulns = asObj(node).vulnerabilities;
+    if (!Array.isArray(vulns)) return;
+    for (const item of vulns) {
+      const v = asObj(item);
+      const title = String(v.title ?? '');
+      if (!title) continue;
+      const refs = asObj(v.references);
+      const f: ToolFinding = {
+        title: `${component}: ${title}`,
+        severity,
+        details: truncate(asStrArray(refs.url).join(' ') || title),
+      };
+      const cves = asStrArray(refs.cve).map((c) => (/^CVE-/i.test(c) ? c : `CVE-${c}`));
+      if (cves.length) f.cve = cves;
+      const fixed = String(v.fixed_in ?? '');
+      if (fixed) f.remediation = `update ${component} to ${fixed}`;
+      out.push(f);
+    }
+  };
+  const version = asObj(doc.version);
+  const coreNum = String(version.number ?? '');
+  if (coreNum) {
+    pushVulns(`WordPress core ${coreNum}`, version, String(version.status ?? '') === 'insecure' ? 'high' : 'medium');
+  }
+  for (const [slug, node] of Object.entries(asObj(doc.plugins))) pushVulns(`plugin ${slug}`, node, 'medium');
+  for (const [slug, node] of Object.entries(asObj(doc.themes))) pushVulns(`theme ${slug}`, node, 'medium');
+  const mainTheme = asObj(doc.main_theme);
+  if (mainTheme.slug) pushVulns(`theme ${String(mainTheme.slug)}`, mainTheme, 'medium');
+  const interesting = doc.interesting_findings;
+  if (Array.isArray(interesting)) {
+    for (const item of interesting) {
+      const o = asObj(item);
+      const label = String(o.to_s ?? o.url ?? '');
+      if (!label) continue;
+      out.push({
+        title: `wpscan: ${truncate(label, 80)}`,
+        severity: 'info',
+        details: [
+          o.url && `url: ${redactString(String(o.url))}`,
+          o.found_by && `found_by: ${String(o.found_by)}`,
+          o.confidence !== undefined && `confidence: ${String(o.confidence)}`,
+        ].filter(Boolean).join(' | '),
+      });
+    }
+  }
+  const users = Object.keys(asObj(doc.users));
+  if (users.length) {
+    out.push({
+      title: `wpscan: ${users.length} user(s) enumerated`,
+      severity: 'info',
+      details: `Usernames: ${users.join(', ')} — valid account names for password-policy review, not proof of compromise.`,
+    });
+  }
+  return out;
+}
+
 const PARSERS: Record<string, (raw: string) => ToolFinding[]> = {
   nuclei: parseNuclei,
   httpx: parseHttpx,
@@ -547,6 +615,7 @@ const PARSERS: Record<string, (raw: string) => ToolFinding[]> = {
   wafw00f: parseWafw00f,
   trufflehog: parseTrufflehog,
   arjun: parseArjun,
+  wpscan: parseWpscan,
 };
 
 /** Adapter ids that have a structured output parser wired here. */


### PR DESCRIPTION
Follow-up to #186, which cataloged wpscan with `parserStatus: 'planned'`. This wires the parser, flipping wpscan to `structured`.

Adds `parseWpscan` to the parser registry (src/arsenal/parsers.ts):
- Core vulns on a core WPScan itself labels `insecure` → **high**; confirmed plugin/theme vulns → **medium**; enumeration/interesting findings → **info**. WPScan never scores severity, so the mapping is documented at the parser, not invented.
- Bare wpvulndb CVE refs (`"2020-11516"`) gain the `CVE-` prefix; `fixed_in` becomes remediation; `fixed_in: null` honestly yields no fix advice.
- Enumerated users collapse into one aggregate info finding; interesting-finding URLs pass through `redactString`.
- Honesty contract holds: empty/garbled input → `[]`, never throws (covered by the shared adversarial-input loop).

Fixture (src/__tests__/fixtures/wpscan.json) follows the real WPScan `--format json` document shape (`version`/`plugins`/`themes`/`interesting_findings`/`users`).

## Contribution Receipt
- Change: wpscan structured parser + fixture + parserStatus flip to `structured`
- Scope class: static_fixture
- Target authority: not_applicable
- Network use: none (fixture-driven parsing only)
- Run mode labels: static_test
- Harness: vitest (parsers), tsc, `npm run test:pr`
- Commands run: `npx tsc --noEmit` (pass); `npm run test:pr` (pass — 923 tests, 82 files)
- Artifacts: this diff
- Redaction: none needed (fixture contains no real target data)
- Claims changed: none (arsenal count unchanged; wpscan's parserStatus label moves planned → structured)
- Residual risk: parser verified against the documented WPScan JSON schema and fixture, not against a live wpscan run; severity mapping (high/medium/info) is a documented convention reviewers may wish to tune