### PR TITLE
feat: add bounded DFIR toolkit

### DIFF
--- a/docs/DFIR_TOOLKIT.md
+++ b/docs/DFIR_TOOLKIT.md
@@ -1,0 +1,26 @@
+# Bounded DFIR toolkit
+
+The toolkit separates read-only evidence acquisition from containment/remediation. It is a library contract, not authorization to investigate or alter a host. Confirm case authority and legal/privacy handling before collection. Route evidence-bearing work to the installed forensics framework and record production incident coordination separately.
+
+## Acquisition and custody
+
+A collector declares its tested platform (`linux`, `darwin`, or `win32`) and returns bytes plus original source and collection timestamp. The toolkit computes SHA-256, verifies the received bytes, records size, collector, target, case, receipt time, transfer method, and redacted metadata. Start the master custody log before acquisition, preserve volatile sources first, and record every later transfer. Permission or collection failures create no invented evidence record; cancellation retains custody records for artifacts already received.
+
+The core makes no blanket operating-system support claim. `supportedDfirPlatforms()` reports only platforms for which the caller supplied a tested collector adapter. No built-in remote-shell commands, memory acquisition, or cloud mutations are implied.
+
+## Containment and remediation
+
+Containment begins with an immutable preview containing the exact case, target, action, steps, summary, rollback guidance, and SHA-256 digest. Execution requires an unexpired approval receipt bound to every one of those identifiers and the exact digest. Missing, expired, mismatched, or stale approval fails closed and invokes no executor. Completion receipts retain completed/total step counts, timestamps, rollback guidance, and fixed errors for partial, failed, or cancelled actions.
+
+Do not reboot, clean, quarantine, rotate credentials, or patch a suspected system merely to prepare evidence. Preserve evidence first unless the incident commander explicitly accepts the tradeoff and the action has a matching receipt. Executors must be narrow platform adapters, stop promptly on cancellation, and report partial progress truthfully.
+
+## Readiness checklist
+
+- Evidence root: `.aiwg/forensics/evidence/<case-id>/`
+- Master custody log: `.aiwg/forensics/chain-of-custody.md`
+- Hash: SHA-256
+- Required identities: case, target, investigator/approver, collector/action
+- Required times: source collection, receipt, approval, execution start/completion
+- Redact secrets and customer data from metadata; evidence bytes stay in the controlled case store
+- Define retention, access, transfer, legal hold, and deletion policy before an incident
+- Test each platform adapter’s permission failure, cancellation, partial execution, and rollback procedure

--- a/src/__tests__/dfir-toolkit.test.ts
+++ b/src/__tests__/dfir-toolkit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createContainmentPreview, DfirToolkit, supportedDfirPlatforms, type ContainmentApproval, type DfirPlatform, type ReadOnlyCollector } from '../dfir/toolkit.js';
+
+const collector = (platform: DfirPlatform = 'linux', collect = vi.fn(async () => [{ name: 'auth.log', source: '/var/log/auth.log', bytes: new TextEncoder().encode('synthetic log'), collectedAt: 100 }])): ReadOnlyCollector => ({ id: `collector-${platform}`, platform, collect });
+const preview = () => createContainmentPreview({ caseId: 'case-1', targetId: 'host-1', actionId: 'isolate-network', summary: 'Remove host from incident VLAN', rollback: 'Restore the prior VLAN assignment', commands: ['inspect-current-vlan', 'apply-quarantine-vlan'] });
+const approval = (digest: string, overrides: Partial<ContainmentApproval> = {}): ContainmentApproval => ({ receiptId: 'receipt-1', caseId: 'case-1', targetId: 'host-1', actionId: 'isolate-network', previewDigest: digest, approvedBy: 'operator-1', approvedAt: 90, expiresAt: 200, ...overrides });
+
+describe('read-only evidence acquisition', () => {
+  it('hashes evidence and emits complete redacted custody fields', async () => {
+    const result = await new DfirToolkit(() => 110).acquire({ caseId: 'case-1', targetId: 'host-1', investigator: 'analyst-1', collector: collector(), metadata: { token: 'private', purpose: 'triage' } });
+    expect(result.outcome).toBe('collected');
+    expect(result.records[0]).toMatchObject({ caseId: 'case-1', targetId: 'host-1', source: '/var/log/auth.log', collectedAt: 100, receivedAt: 110, sizeBytes: 13, collector: 'collector-linux', transfer: 'in-process', verified: true, redactedMetadata: { token: '[redacted]', purpose: 'triage' } });
+    expect(result.records[0].sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+  it('reports permission failure without fabricating custody records', async () => {
+    const collect = vi.fn().mockRejectedValue(new Error('EACCES secret path'));
+    await expect(new DfirToolkit().acquire({ caseId: 'case-1', targetId: 'host-1', investigator: 'analyst-1', collector: collector('linux', collect) })).resolves.toEqual({ outcome: 'permission-denied', records: [], error: 'permission-denied' });
+  });
+  it('preserves already collected records when cancellation occurs between artifacts', async () => {
+    const controller = new AbortController();
+    const collect = vi.fn(async () => [{ name: 'one', source: '/one', bytes: new Uint8Array([1]), collectedAt: 1 }, { get name() { controller.abort(); return 'two'; }, source: '/two', bytes: new Uint8Array([2]), collectedAt: 2 }]);
+    const result = await new DfirToolkit().acquire({ caseId: 'case-1', targetId: 'host-1', investigator: 'analyst-1', collector: collector('linux', collect), signal: controller.signal });
+    expect(result).toMatchObject({ outcome: 'cancelled' });
+    expect(result.records).toHaveLength(1);
+  });
+  it('claims only platforms supplied by tested adapters', () => {
+    expect(supportedDfirPlatforms([collector('linux'), collector('darwin'), collector('win32')])).toEqual(['linux', 'darwin', 'win32']);
+    expect(supportedDfirPlatforms([collector('linux')])).toEqual(['linux']);
+  });
+});
+
+describe('authorization-gated containment', () => {
+  it('denies absent, expired, mismatched-target, and changed-preview approvals', async () => {
+    const action = preview(); const executor = { execute: vi.fn() }; const toolkit = new DfirToolkit(() => 100);
+    for (const receipt of [undefined, approval(action.digest, { expiresAt: 100 }), approval(action.digest, { targetId: 'other' }), approval('0'.repeat(64))]) {
+      await expect(toolkit.contain(action, receipt, executor)).resolves.toMatchObject({ outcome: 'denied', completedSteps: 0, rollback: action.rollback });
+    }
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+  it('executes an exact approved preview and records success', async () => {
+    const action = preview(); const executor = { execute: vi.fn().mockResolvedValue({ completedSteps: 2, totalSteps: 2 }) };
+    await expect(new DfirToolkit(() => 100).contain(action, approval(action.digest), executor)).resolves.toMatchObject({ outcome: 'completed', completedSteps: 2, totalSteps: 2, rollback: action.rollback });
+    expect(executor.execute).toHaveBeenCalledOnce();
+  });
+  it('records partial execution and rollback guidance', async () => {
+    const action = preview(); const executor = { execute: vi.fn().mockResolvedValue({ completedSteps: 1, totalSteps: 2 }) };
+    await expect(new DfirToolkit(() => 100).contain(action, approval(action.digest), executor)).resolves.toMatchObject({ outcome: 'partial', completedSteps: 1, error: 'partial-execution', rollback: 'Restore the prior VLAN assignment' });
+  });
+  it('does not invoke containment when already cancelled', async () => {
+    const action = preview(); const controller = new AbortController(); controller.abort(); const executor = { execute: vi.fn() };
+    await expect(new DfirToolkit(() => 100).contain(action, approval(action.digest), executor, controller.signal)).resolves.toMatchObject({ outcome: 'cancelled' });
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/dfir/toolkit.ts
+++ b/src/dfir/toolkit.ts
@@ -1,0 +1,74 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { redactSecrets } from '../redact.js';
+
+export type DfirPlatform = 'linux' | 'darwin' | 'win32';
+export interface EvidenceArtifact { name: string; source: string; bytes: Uint8Array; collectedAt: number }
+export interface EvidenceRecord { id: string; caseId: string; targetId: string; name: string; source: string; collectedAt: number; receivedAt: number; sha256: string; sizeBytes: number; collector: string; transfer: 'in-process'; verified: boolean; redactedMetadata: Record<string, unknown> }
+export interface ReadOnlyCollector {
+  readonly id: string;
+  readonly platform: DfirPlatform;
+  collect(targetId: string, signal?: AbortSignal): Promise<readonly EvidenceArtifact[]>;
+}
+export interface AcquisitionRequest { caseId: string; targetId: string; investigator: string; collector: ReadOnlyCollector; signal?: AbortSignal; metadata?: Record<string, unknown> }
+export interface AcquisitionResult { outcome: 'collected' | 'cancelled' | 'permission-denied' | 'collection-failed'; records: EvidenceRecord[]; error?: string }
+
+export interface ContainmentPreview { caseId: string; targetId: string; actionId: string; summary: string; rollback: string; commands: readonly string[]; digest: string }
+export interface ContainmentApproval { receiptId: string; caseId: string; targetId: string; actionId: string; previewDigest: string; approvedBy: string; approvedAt: number; expiresAt: number }
+export interface ContainmentExecutor { execute(preview: ContainmentPreview, signal?: AbortSignal): Promise<{ completedSteps: number; totalSteps: number }> }
+export interface ContainmentReceipt { receiptId: string; caseId: string; targetId: string; actionId: string; outcome: 'completed' | 'partial' | 'cancelled' | 'denied' | 'failed'; completedSteps: number; totalSteps: number; startedAt: number; completedAt: number; rollback: string; error?: string }
+
+const idPattern = /^[a-zA-Z0-9_.:-]{1,128}$/;
+const sha256 = (value: Uint8Array | string) => createHash('sha256').update(value).digest('hex');
+const safeError = (error: unknown): AcquisitionResult['outcome'] => error instanceof Error && /EACCES|EPERM|permission/i.test(error.message) ? 'permission-denied' : 'collection-failed';
+
+export function createContainmentPreview(input: Omit<ContainmentPreview, 'digest'>): ContainmentPreview {
+  if (![input.caseId, input.targetId, input.actionId].every(value => idPattern.test(value)) || !input.summary.trim() || !input.rollback.trim() || !input.commands.length) throw new Error('Containment preview is incomplete');
+  const canonical = JSON.stringify({ caseId: input.caseId, targetId: input.targetId, actionId: input.actionId, summary: input.summary, rollback: input.rollback, commands: input.commands });
+  return { ...structuredClone(input), digest: sha256(canonical) };
+}
+
+export class DfirToolkit {
+  constructor(private readonly now: () => number = Date.now) {}
+
+  async acquire(request: AcquisitionRequest): Promise<AcquisitionResult> {
+    if (![request.caseId, request.targetId, request.investigator, request.collector.id].every(value => idPattern.test(value))) return { outcome: 'collection-failed', records: [], error: 'invalid-request' };
+    if (request.signal?.aborted) return { outcome: 'cancelled', records: [] };
+    try {
+      const artifacts = await request.collector.collect(request.targetId, request.signal);
+      const names = new Set<string>();
+      const records: EvidenceRecord[] = [];
+      for (const artifact of artifacts) {
+        if (request.signal?.aborted) return { outcome: 'cancelled', records };
+        const name = artifact.name;
+        if (request.signal?.aborted) return { outcome: 'cancelled', records };
+        if (!name || names.has(name) || !artifact.source || !Number.isFinite(artifact.collectedAt)) return { outcome: 'collection-failed', records, error: 'invalid-artifact' };
+        names.add(name);
+        const digest = sha256(artifact.bytes);
+        records.push({ id: randomUUID(), caseId: request.caseId, targetId: request.targetId, name, source: artifact.source, collectedAt: artifact.collectedAt, receivedAt: this.now(), sha256: digest, sizeBytes: artifact.bytes.byteLength, collector: request.collector.id, transfer: 'in-process', verified: sha256(artifact.bytes) === digest, redactedMetadata: redactSecrets(request.metadata ?? {}) as Record<string, unknown> });
+      }
+      return { outcome: 'collected', records };
+    } catch (error) {
+      return { outcome: safeError(error), records: [], error: safeError(error) };
+    }
+  }
+
+  async contain(preview: ContainmentPreview, approval: ContainmentApproval | undefined, executor: ContainmentExecutor, signal?: AbortSignal): Promise<ContainmentReceipt> {
+    const startedAt = this.now();
+    const base = { receiptId: approval?.receiptId ?? randomUUID(), caseId: preview.caseId, targetId: preview.targetId, actionId: preview.actionId, startedAt, rollback: preview.rollback };
+    const denied = !approval || !idPattern.test(approval.receiptId) || !idPattern.test(approval.approvedBy) || approval.caseId !== preview.caseId || approval.targetId !== preview.targetId || approval.actionId !== preview.actionId || approval.previewDigest !== preview.digest || approval.approvedAt > startedAt || approval.expiresAt <= startedAt;
+    if (denied) return { ...base, outcome: 'denied', completedSteps: 0, totalSteps: preview.commands.length, completedAt: this.now(), error: 'authorization-required' };
+    if (signal?.aborted) return { ...base, outcome: 'cancelled', completedSteps: 0, totalSteps: preview.commands.length, completedAt: this.now(), error: 'cancelled' };
+    try {
+      const result = await executor.execute(structuredClone(preview), signal);
+      const completedSteps = Math.max(0, Math.min(preview.commands.length, Math.trunc(result.completedSteps)));
+      const totalSteps = preview.commands.length;
+      return { ...base, outcome: signal?.aborted ? 'cancelled' : completedSteps === totalSteps ? 'completed' : 'partial', completedSteps, totalSteps, completedAt: this.now(), ...(completedSteps === totalSteps ? {} : { error: signal?.aborted ? 'cancelled' : 'partial-execution' }) };
+    } catch {
+      return { ...base, outcome: signal?.aborted ? 'cancelled' : 'failed', completedSteps: 0, totalSteps: preview.commands.length, completedAt: this.now(), error: signal?.aborted ? 'cancelled' : 'execution-failed' };
+    }
+  }
+}
+
+export function supportedDfirPlatforms(collectors: readonly ReadOnlyCollector[]): DfirPlatform[] {
+  return [...new Set(collectors.map(collector => collector.platform))];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1651,4 +1651,5 @@ export * from './integrations/alerts.js';
 export * from './persistence/supabase.js';
 export * from './persistence/migrations.js';
 export * from './mission/recovery.js';
+export * from './dfir/toolkit.js';
 export * from './llm/context-compression.js';


### PR DESCRIPTION
## Summary

- add a bounded DFIR library that strictly separates read-only acquisition from containment/remediation
- generate SHA-256-verified custody records with source and receipt timestamps, target/case identity, collector, size, transfer, and redacted metadata
- require an unexpired approval bound to the exact case, target, action, and preview digest before mutation
- retain partial-step truth, cancellation, fixed failure categories, audit receipt data, and rollback guidance
- report only platforms represented by supplied tested collector adapters

## Verification

- `COVERAGE_BASE=upstream/main npm run test:pr-coverage` — 84 files, 938 tests; 40/40 changed executable lines (100%)
- `npm run test:pr` — pass
- `npm run docs:check` — pass
- `npm run verify-claims` — 27 passed, 0 failed

Closes #180

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
