### PR TITLE
feat: add CVE Vault search interface

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -105,6 +105,15 @@ Tool requests should be scoped to authorized targets. External binary availabili
 | `POST` | `/api/admiral/suggest` | Request mission suggestions |
 | `POST` | `/api/admiral/launch` | Launch from Admiral flow |
 
+## CVE Vault
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/cve-vault/search` | Search server-refreshed CISA KEV and optional FIRST EPSS data by observed technology |
+| `POST` | `/api/recon/correlate-cves` | Correlate observations with caller-supplied, already-ingested feed snapshots |
+
+`POST /api/cve-vault/search` accepts `{ "query": "vendor or product" }`. Results are always `unverified-candidate` records and include CISA/FIRST provenance, retrieval timestamps, stale state, warnings, and any per-feed refresh errors. A CVE match does not establish that the observed version is affected. The endpoint returns `503` when neither fresh nor cached CISA KEV data exists.
+
 ## Evidence, Findings, And Retests
 
 | Method | Path | Purpose |

--- a/docs/cve-vault.css
+++ b/docs/cve-vault.css
@@ -1,0 +1,9 @@
+.cve-vault-controls { display:grid; grid-template-columns:minmax(14rem,1fr) auto auto; gap:.75rem; margin-bottom:1rem; }
+.cve-vault-controls input,.cve-vault-controls select { background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border-color); border-radius:6px; padding:.7rem; }
+.cve-vault-layout { display:grid; grid-template-columns:minmax(18rem,1fr) minmax(18rem,1fr); gap:1rem; }
+.cve-vault-results { display:grid; gap:.5rem; }
+.cve-vault-row { display:grid; grid-template-columns:1fr 1.5fr 1fr auto; gap:.6rem; width:100%; padding:.75rem; text-align:left; color:var(--text-secondary); background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:6px; }
+.cve-vault-row[aria-selected="true"],.cve-vault-row:focus-visible { border-color:var(--accent); outline:2px solid var(--accent-glow); color:var(--text-primary); }
+.cve-vault-detail { border-left:3px solid var(--accent); padding:0 1rem; line-height:1.55; }
+.cve-vault-status { color:var(--text-secondary); margin:.5rem 0 1rem; }
+@media (max-width:800px) { .cve-vault-controls,.cve-vault-layout { grid-template-columns:1fr; } .cve-vault-row { grid-template-columns:1fr 1fr; } }

--- a/docs/cve-vault.js
+++ b/docs/cve-vault.js
@@ -1,0 +1,58 @@
+(function () {
+  'use strict';
+  var state = { status: 'idle', matches: [], source: null, warnings: [], feedErrors: {}, error: '', filter: 'all', selected: 0, cached: false };
+  var root;
+  function el(tag, text, className) { var node = document.createElement(tag); if (text !== undefined) node.textContent = text; if (className) node.className = className; return node; }
+  function visible() { return state.matches.filter(function (m) { return state.filter === 'all' || (state.filter === 'epss' ? Boolean(m.epss) : state.filter === 'stale' ? m.stale : !m.stale); }); }
+  function sourceText() {
+    if (!state.source || !state.source.kev) return '';
+    var text = 'CISA KEV · retrieved ' + state.source.kev.retrievedAt;
+    if (state.source.epss) text += ' · FIRST EPSS ' + state.source.epss.retrievedAt;
+    var refreshErrors = Object.keys(state.feedErrors || {});
+    if (refreshErrors.length) text += ' · refresh warning: ' + refreshErrors.join(', ');
+    if (state.warnings.length) text += ' · ' + state.warnings.join(' ');
+    return text;
+  }
+  function render() {
+    if (!root) return;
+    var status = root.querySelector('[data-vault-status]'); var list = root.querySelector('[data-vault-results]'); var detail = root.querySelector('[data-vault-detail]');
+    root.setAttribute('aria-busy', state.status === 'loading' ? 'true' : 'false'); list.replaceChildren(); detail.replaceChildren();
+    if (state.status === 'loading') status.textContent = 'Loading current server-side feed snapshot…';
+    else if (state.error) status.textContent = 'Error: ' + state.error + (state.cached ? ' Showing the last successful local view as stale.' : '');
+    else if (state.status === 'ready' && !visible().length) status.textContent = state.matches.length ? 'No results match this filter.' : 'No candidates matched. Absence is not evidence of safety.';
+    else status.textContent = sourceText() || 'Enter a vendor or product to search audited server-side feeds.';
+    var rows = visible(); if (state.selected >= rows.length) state.selected = Math.max(0, rows.length - 1);
+    rows.forEach(function (match, index) {
+      var button = el('button', '', 'cve-vault-row'); button.type = 'button'; button.setAttribute('role', 'option'); button.setAttribute('aria-selected', String(index === state.selected)); button.tabIndex = index === state.selected ? 0 : -1;
+      button.append(el('strong', match.cveId), el('span', match.vendor + ' · ' + match.product), el('span', match.epss ? 'EPSS ' + Math.round(match.epss.score * 100) + '%' : 'EPSS unavailable'), el('span', match.stale ? 'STALE' : 'CURRENT'));
+      button.addEventListener('click', function () { state.selected = index; render(); });
+      button.addEventListener('keydown', function (event) { if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Home' && event.key !== 'End') return; event.preventDefault(); state.selected = event.key === 'Home' ? 0 : event.key === 'End' ? rows.length - 1 : (index + (event.key === 'ArrowDown' ? 1 : -1) + rows.length) % rows.length; render(); root.querySelectorAll('.cve-vault-row')[state.selected]?.focus(); });
+      list.append(button);
+    });
+    var selected = rows[state.selected];
+    if (selected) {
+      detail.append(el('h3', selected.cveId + ' — unverified candidate'), el('p', selected.vulnerabilityName), el('p', 'Matched ' + selected.technology.name + ' by ' + selected.matchBasis + '; version status: ' + selected.versionStatus + '.'), el('p', 'CISA added ' + selected.kev.dateAdded + '; required action: ' + selected.kev.requiredAction), el('p', selected.epss ? 'FIRST EPSS ' + selected.epss.score + ' (percentile ' + selected.epss.percentile + ', scored ' + selected.epss.scoreDate + '). Probability is not impact.' : 'FIRST EPSS context is unavailable.'), el('p', 'Source: ' + selected.kev.provenance.sourceUrl + ' · retrieved ' + selected.kev.provenance.retrievedAt));
+    }
+  }
+  async function search(event) {
+    event.preventDefault(); var query = root.querySelector('[data-vault-query]').value.trim(); if (!query) return;
+    state.status = 'loading'; state.error = ''; state.cached = false; render();
+    try {
+      var response = await fetch('/api/cve-vault/search', { method: 'POST', headers: { 'content-type': 'application/json', accept: 'application/json' }, body: JSON.stringify({ query: query }) });
+      var body = await response.json(); if (!response.ok) throw new Error(body.error || 'Search failed');
+      state = { status: 'ready', matches: Array.isArray(body.matches) ? body.matches : [], source: body.source, warnings: body.warnings || [], feedErrors: body.feedErrors || {}, error: '', filter: state.filter, selected: 0, cached: false };
+      try { sessionStorage.setItem('t3mp3st_cve_vault_last', JSON.stringify({ matches: state.matches, source: state.source, warnings: state.warnings, feedErrors: state.feedErrors })); } catch (_) {}
+    } catch (error) {
+      var cached; try { cached = JSON.parse(sessionStorage.getItem('t3mp3st_cve_vault_last') || 'null'); } catch (_) {}
+      state.status = 'error'; state.error = error instanceof Error ? error.message : 'Search failed'; state.matches = cached?.matches || []; state.source = cached?.source || null; state.warnings = cached?.warnings || []; state.feedErrors = cached?.feedErrors || {}; state.cached = Boolean(cached); state.selected = 0;
+    } render();
+  }
+  function init() {
+    root = document.getElementById('cveVaultApp'); if (!root || root.dataset.ready) return; root.dataset.ready = 'true';
+    root.querySelector('form').addEventListener('submit', search);
+    root.querySelector('[data-vault-filter]').addEventListener('change', function (event) { state.filter = event.target.value; state.selected = 0; render(); });
+    render();
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+  window.cveVault = { init: init };
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text y='28' font-size='28'>⚡</text></svg>">
     <title>T3MP3ST - Command & Control Dashboard</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="cve-vault.css" rel="stylesheet">
     <script>
         // Apply the saved theme before first paint (no flash of default theme).
         try { var _t3mpTheme = localStorage.getItem('t3mp3st_theme'); if (_t3mpTheme && _t3mpTheme !== 'storm') document.documentElement.setAttribute('data-theme', _t3mpTheme); } catch (e) {}
@@ -3492,6 +3493,9 @@
                 <div class="nav-item" data-page="evidence">
                     <span class="icon">🔐</span> Evidence Vault
                 </div>
+                <div class="nav-item" data-page="cve-vault">
+                    <span class="icon">🛡️</span> CVE Vault
+                </div>
 
                 <div class="nav-label">Ranges</div>
                 <div class="nav-item" data-page="benchmarks">
@@ -6045,6 +6049,20 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                         <button class="btn btn-primary" onclick="navigateTo('settings')">Configure API Keys →</button>
                     </div>
                 </div>
+                <div class="page" id="page-cve-vault">
+                    <div class="card" id="cveVaultApp" aria-labelledby="cveVaultTitle" aria-busy="false">
+                        <div class="card-header"><h2 class="card-title" id="cveVaultTitle">CVE Vault</h2></div>
+                        <p>Search CISA KEV with optional FIRST EPSS context. Matches are candidates, not proof that an observed version is vulnerable.</p>
+                        <form class="cve-vault-controls">
+                            <label>Vendor or product <input data-vault-query required maxlength="200" autocomplete="off" placeholder="e.g. Apache HTTP Server"></label>
+                            <label>Filter <select data-vault-filter><option value="all">All</option><option value="epss">Has EPSS</option><option value="fresh">Current feeds</option><option value="stale">Stale feeds</option></select></label>
+                            <button class="btn btn-primary" type="submit">Search</button>
+                        </form>
+                        <noscript>CVE Vault search requires JavaScript. Use POST /api/cve-vault/search from a local API client.</noscript>
+                        <p class="cve-vault-status" data-vault-status role="status" aria-live="polite"></p>
+                        <div class="cve-vault-layout"><div class="cve-vault-results" data-vault-results role="listbox" aria-label="CVE candidates"></div><article class="cve-vault-detail" data-vault-detail aria-live="polite"></article></div>
+                    </div>
+                </div>
             </div>
         </main>
     </div>
@@ -7667,7 +7685,7 @@ Correlating findings across agents, identifying patterns, producing actionable i
         function navigateTo(page) {
             document.querySelectorAll('.nav-item').forEach(i => i.classList.toggle('active', i.dataset.page === page));
             document.querySelectorAll('.page').forEach(p => p.classList.toggle('active', p.id === `page-${page}`));
-            const titles = { warroom: 'War Room', 'live-scan': 'Live Scan', receipts: 'Scope Receipts', operators: 'Operatives', evidence: 'Evidence Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
+            const titles = { warroom: 'War Room', 'live-scan': 'Live Scan', receipts: 'Scope Receipts', operators: 'Operatives', evidence: 'Evidence Vault', 'cve-vault': 'CVE Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
             document.getElementById('pageTitle').textContent = titles[page] || 'War Room';
             document.getElementById('sidebar').classList.remove('open');
             if (page === 'live-scan') setTimeout(() => window.refreshLiveScanPage?.(), 50);
@@ -27503,5 +27521,6 @@ Be specific and actionable. Format as structured JSON.`;
 </script>
 <script src="sounds.js"></script>
 <script src="findings-sort.js"></script>
+<script src="cve-vault.js"></script>
 </body>
 </html>

--- a/docsite/t3mp3st-docs/content/API_REFERENCE.md
+++ b/docsite/t3mp3st-docs/content/API_REFERENCE.md
@@ -116,6 +116,15 @@ Tool requests should be scoped to authorized targets. External binary availabili
 | `POST` | `/api/admiral/suggest` | Request mission suggestions |
 | `POST` | `/api/admiral/launch` | Launch from Admiral flow |
 
+## CVE Vault
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/cve-vault/search` | Search server-refreshed CISA KEV and optional FIRST EPSS data by observed technology |
+| `POST` | `/api/recon/correlate-cves` | Correlate observations with caller-supplied, already-ingested feed snapshots |
+
+`POST /api/cve-vault/search` accepts `{ "query": "vendor or product" }`. Results are always `unverified-candidate` records and include CISA/FIRST provenance, retrieval timestamps, stale state, warnings, and any per-feed refresh errors. A CVE match does not establish that the observed version is affected. The endpoint returns `503` when neither fresh nor cached CISA KEV data exists.
+
 ## Evidence, Findings, And Retests
 
 | Method | Path | Purpose |

--- a/src/__tests__/cve-vault.test.ts
+++ b/src/__tests__/cve-vault.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { CveVaultService } from '../threat-intel/vault.js';
+import type { FeedProvenance, FeedResult, KevRecord } from '../threat-intel/feed.js';
+
+const provenance: FeedProvenance = { source: 'cisa-kev', sourceUrl: 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog', retrievedAt: '2026-09-03T00:00:00Z', schemaVersion: '1' };
+const kev: FeedResult<KevRecord> = { state: 'fresh', stale: false, cachedAt: provenance.retrievedAt, provenance, records: [{ cveId: 'CVE-2026-1234', vendor: 'Acme', product: 'Widget', vulnerabilityName: 'Widget flaw', dateAdded: '2026-09-01', dueDate: '2026-09-20', requiredAction: 'Apply update', knownRansomwareCampaignUse: 'Unknown', provenance }] };
+
+describe('CVE Vault server composition contract', () => {
+  it('refreshes server-side feeds and returns provenance-honest candidates', async () => {
+    const refresh = vi.fn().mockResolvedValue({ kev, errors: {} });
+    const result = await new CveVaultService({ refresh }).search({ query: 'Acme Widget' });
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ status: 200, body: { matches: [{ cveId: 'CVE-2026-1234', verificationStatus: 'unverified-candidate', versionStatus: 'not-provided', stale: false }], source: { kev: provenance }, feedErrors: {} } });
+  });
+  it('preserves cached/stale state and feed refresh errors', async () => {
+    const stale = { ...kev, state: 'cached' as const, stale: true };
+    const result = await new CveVaultService({ refresh: async () => ({ kev: stale, errors: { 'cisa-kev': 'network unavailable' } }) }).search({ query: 'Widget' });
+    expect(result).toMatchObject({ status: 200, body: { matches: [{ stale: true, confidence: 0.5 }], feedErrors: { 'cisa-kev': 'network unavailable' } } });
+  });
+  it('validates query and fails honestly without fresh or cached KEV', async () => {
+    const service = new CveVaultService({ refresh: async () => ({ errors: { 'cisa-kev': 'offline' } }) });
+    await expect(service.search({ query: '' })).resolves.toMatchObject({ status: 400 });
+    await expect(service.search({ query: 'Widget' })).resolves.toEqual({ status: 503, body: { error: 'CISA KEV feed is unavailable and no cached snapshot exists' } });
+  });
+});
+
+describe('CVE Vault browser contract', () => {
+  const html = readFileSync('docs/index.html', 'utf8');
+  const js = readFileSync('docs/cve-vault.js', 'utf8');
+  it('mounts one navigable main-content page with no-JavaScript fallback', () => {
+    expect(html.match(/id="page-cve-vault"/g)).toHaveLength(1);
+    expect(html.indexOf('id="page-cve-vault"')).toBeGreaterThan(html.indexOf('<div class="page-content">'));
+    expect(html.indexOf('id="page-cve-vault"')).toBeLessThan(html.indexOf('</main>'));
+    expect(html).toContain('<noscript>CVE Vault search requires JavaScript.');
+  });
+  it('covers loading, empty, error, stale, filter, source, and keyboard states without HTML injection', () => {
+    for (const token of ['Loading current server-side feed snapshot', 'No candidates matched', 'Error:', 'Showing the last successful local view as stale', "state.filter === 'epss'", "event.key === 'ArrowDown'", "event.key === 'Home'", 'aria-selected', 'retrieved ']) expect(js).toContain(token);
+    expect(js).not.toContain('innerHTML');
+    expect(js).toContain("fetch('/api/cve-vault/search'");
+  });
+  it('does not add config APIs, CORS overrides, arbitrary origins, or dotenv loading', () => {
+    const changed = [js, readFileSync('src/threat-intel/vault.ts', 'utf8')].join('\n');
+    expect(changed).not.toMatch(/api\/config\/env|access-control-allow-origin|process\.cwd|dotenv/i);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1644,6 +1644,7 @@ export default createTempest;
 
 export * from './threat-intel/feed.js';
 export * from './threat-intel/correlation.js';
+export * from './threat-intel/vault.js';
 export * from './llm/tool-call-boundary.js';
 export * from './evidence/retest.js';
 export * from './deception/honeytokens.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -7688,6 +7688,9 @@ import {
   ATTACK_GRAPH_SCHEMA, type AttackGraph,
 } from './recon/attack-graph.js';
 import { handleCorrelationApi } from './threat-intel/correlation.js';
+import { CveVaultService } from './threat-intel/vault.js';
+
+const cveVaultService = new CveVaultService();
 
 /**
  * POST /api/recon/correlate-cves — correlate observed technology names with an
@@ -7696,6 +7699,12 @@ import { handleCorrelationApi } from './threat-intel/correlation.js';
  */
 app.post('/api/recon/correlate-cves', (req: Request, res: Response): void => {
   const result = handleCorrelationApi(req.body);
+  res.status(result.status).json(result.body);
+});
+
+/** POST /api/cve-vault/search — refresh audited feeds server-side and return unverified candidates. */
+app.post('/api/cve-vault/search', async (req: Request, res: Response): Promise<void> => {
+  const result = await cveVaultService.search(req.body);
   res.status(result.status).json(result.body);
 });
 

--- a/src/threat-intel/vault.ts
+++ b/src/threat-intel/vault.ts
@@ -1,0 +1,18 @@
+import { correlateTechnologies, type CorrelationResponse } from './correlation.js';
+import { ThreatFeedClient, type ThreatFeedSnapshot } from './feed.js';
+
+export interface CveVaultSearchResponse extends CorrelationResponse { feedErrors: ThreatFeedSnapshot['errors'] }
+export interface CveVaultSearchResult { status: 200 | 400 | 503; body: CveVaultSearchResponse | { error: string } }
+
+export class CveVaultService {
+  constructor(private readonly feeds: Pick<ThreatFeedClient, 'refresh'> = new ThreatFeedClient()) {}
+  async search(body: unknown): Promise<CveVaultSearchResult> {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) return { status: 400, body: { error: 'request body must be an object' } };
+    const query = (body as Record<string, unknown>).query;
+    if (typeof query !== 'string' || !query.trim() || query.length > 200) return { status: 400, body: { error: 'query must be a non-empty string of at most 200 characters' } };
+    const snapshot = await this.feeds.refresh();
+    if (!snapshot.kev) return { status: 503, body: { error: 'CISA KEV feed is unavailable and no cached snapshot exists' } };
+    const response = correlateTechnologies({ technologies: [{ name: query.trim(), source: 'cve-vault-search' }], kev: snapshot.kev, ...(snapshot.epss ? { epss: snapshot.epss } : {}) });
+    return { status: 200, body: { ...response, feedErrors: snapshot.errors } };
+  }
+}


### PR DESCRIPTION
Closes #173.

## Summary

- add a documented same-origin CVE Vault search endpoint that composes the existing feed and correlation services
- add the CVE Vault search/detail interface with accessible keyboard navigation and explicit loading, empty, error, and stale-cache states
- display source, retrieval time, KEV, EPSS, and uncertainty context without treating correlations as confirmed vulnerabilities
- preserve the server's global origin boundary and avoid configuration, origin-reflection, and target-repository `.env` surfaces

## Verification

- `npm run test:pr` — 85 files, 944 tests passed
- `COVERAGE_BASE=upstream/main PR_CHANGED_LINE_COVERAGE=50 npm run test:pr-coverage` — 8/13 changed executable lines, 61.5%
- `npm run docs:check` — passed
- `npm run verify-claims` — 27/27 passed
- `node --check docs/cve-vault.js` — passed

## Security and trust assessment

The browser submits only a search string to a same-origin endpoint. Feed retrieval remains server-side through the existing allowlisted client. Remote values are rendered with text-only DOM APIs. The change adds no CORS override, arbitrary Origin reflection, browser secret/config endpoint, credential persistence, or cwd `.env` loading. Stale data is labeled and unavailable data fails explicitly.

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
