### PR TITLE
feat: establish incremental application shell

### DIFF
--- a/docs/APP_SHELL.md
+++ b/docs/APP_SHELL.md
@@ -1,0 +1,21 @@
+# Incremental Application Shell
+
+The dashboard remains a rendered HTML application while its shell is migrated module by module. `docs/index.html` is the canonical rendered source served by `/ui/`; `docs/app-shell.js` is the single source for shared route activation, hash deep links, keyboard activation, route lifecycle callbacks, and server-readiness presentation. Do not copy either asset into a per-module page.
+
+## Accepted first module
+
+CVE Vault is the representative first migration. Its navigation entry carries `data-shell-module="true"`, its rendered page remains in `docs/index.html`, and its behavior remains in self-hosted external scripts. This preserves useful content and the API fallback when JavaScript is unavailable. `#/cve-vault` is the stable deep link.
+
+The readiness label is updated only from the same-origin `/api/health` response. The external shell performs a bounded probe so the representative module remains truthful under a self-only script policy; the existing API client can publish subsequent health results. Browser-stored keys or guessed provider state do not make API or LLM readiness claims. Offline and standalone states are explicit.
+
+## Reproducible migration recipe
+
+1. Start from current `main`; migrate one module in one focused PR.
+2. Keep one rendered `.page` in `docs/index.html` with a unique `page-<route>` id and a no-JavaScript/error fallback.
+3. Add one `.nav-item[data-page="<route>"]`; mark the migrated entry with `data-shell-module="true"`.
+4. Register the title and any idempotent lifecycle callback once in `docs/app-shell.js`.
+5. Put module behavior and styles in self-hosted external assets. Do not add inline event handlers, `eval`, remote executable content, origin overrides, or browser secret/config endpoints.
+6. Extend `src/__tests__/app-shell.test.ts` with route, deep-link, readiness, keyboard, CSP, and stable layout assertions.
+7. Run `node --check docs/app-shell.js`, `npm run test:pr`, the changed-line coverage gate, and `npm run docs:check`.
+
+The documentation build synchronizes Markdown into the Pagenary docsite. It does not generate or duplicate dashboard source. Remaining dashboard modules should migrate only after this pattern is accepted.

--- a/docs/app-shell.js
+++ b/docs/app-shell.js
@@ -1,0 +1,118 @@
+(function () {
+  'use strict';
+
+  var titles = {
+    warroom: 'War Room', 'live-scan': 'Live Scan', receipts: 'Scope Receipts',
+    operators: 'Operatives', evidence: 'Evidence Vault', 'cve-vault': 'CVE Vault',
+    arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks',
+    configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral',
+    selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About'
+  };
+  var initialized = false;
+
+  function routeFromHash() {
+    var match = /^#\/?([a-z0-9-]+)$/.exec(window.location.hash || '');
+    return match && titles[match[1]] ? match[1] : null;
+  }
+
+  function writeHash(page, mode) {
+    if (mode === 'none' || !window.history) return;
+    var hash = '#/' + page;
+    if (window.location.hash === hash) return;
+    var method = mode === 'push' ? 'pushState' : 'replaceState';
+    window.history[method](null, '', hash);
+  }
+
+  function runLifecycle(page) {
+    var callbacks = {
+      'live-scan': ['refreshLiveScanPage', 50], receipts: ['refreshReceiptsPage', 50],
+      operators: ['loadOperativesRoster', 80], evidence: ['hydrateFindings', 60],
+      selfimprove: ['renderSelfImprove', 60], settings: ['uacInit', 40],
+      'ctf-range': ['initCtfRange', 0]
+    };
+    var callback = callbacks[page];
+    if (callback && typeof window[callback[0]] === 'function') {
+      window.setTimeout(window[callback[0]], callback[1]);
+    }
+  }
+
+  function navigate(page, options) {
+    if (!titles[page] || !document.getElementById('page-' + page)) return false;
+    document.querySelectorAll('.nav-item').forEach(function (item) {
+      item.classList.toggle('active', item.dataset.page === page);
+      if (item.dataset.page === page) item.setAttribute('aria-current', 'page');
+      else item.removeAttribute('aria-current');
+    });
+    document.querySelectorAll('.page').forEach(function (panel) {
+      var active = panel.id === 'page-' + page;
+      panel.classList.toggle('active', active);
+      panel.hidden = !active;
+    });
+    var title = document.getElementById('pageTitle');
+    var sidebar = document.getElementById('sidebar');
+    if (title) title.textContent = titles[page];
+    if (sidebar) sidebar.classList.remove('open');
+    writeHash(page, options && options.history ? options.history : 'replace');
+    runLifecycle(page);
+    document.dispatchEvent(new CustomEvent('t3mp:navigate', { detail: { page: page } }));
+    return true;
+  }
+
+  function readinessText(payload) {
+    if (payload && payload.status === 'operational') {
+      if (payload.llm && payload.llm.connected) return { state: 'ready', text: 'API and LLM ready (server verified)' };
+      return { state: 'limited', text: 'API ready; LLM unavailable (server verified)' };
+    }
+    if (payload && payload.status === 'standalone') return { state: 'limited', text: 'Standalone mode; server readiness unavailable' };
+    return { state: 'offline', text: 'API offline; LLM readiness unavailable' };
+  }
+
+  function updateReadiness(payload) {
+    var status = readinessText(payload);
+    document.querySelectorAll('[data-shell-readiness]').forEach(function (node) {
+      node.textContent = status.text;
+      node.dataset.state = status.state;
+    });
+    return status;
+  }
+
+  async function refreshReadiness() {
+    var controller = new AbortController();
+    var timeout = window.setTimeout(function () { controller.abort(); }, 5000);
+    try {
+      var response = await fetch('/api/health', { headers: { accept: 'application/json' }, signal: controller.signal });
+      if (!response.ok) throw new Error('health request failed');
+      return updateReadiness(await response.json());
+    } catch (_) {
+      return updateReadiness({ status: 'offline' });
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }
+
+  function init() {
+    if (initialized) return;
+    initialized = true;
+    document.querySelectorAll('.nav-item[data-page]').forEach(function (item) {
+      item.setAttribute('role', 'link');
+      item.tabIndex = 0;
+      item.addEventListener('click', function () { navigate(item.dataset.page, { history: 'push' }); });
+      item.addEventListener('keydown', function (event) {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        navigate(item.dataset.page, { history: 'push' });
+      });
+    });
+    var active = document.querySelector('.nav-item.active[data-page]');
+    var initial = routeFromHash() || (active && active.dataset.page) || 'warroom';
+    navigate(initial, { history: 'none' });
+    refreshReadiness();
+    window.addEventListener('hashchange', function () {
+      var page = routeFromHash();
+      if (page) navigate(page, { history: 'none' });
+    });
+  }
+
+  window.T3MP3STShell = { init: init, navigate: navigate, updateReadiness: updateReadiness, refreshReadiness: refreshReadiness, readinessText: readinessText, routeFromHash: routeFromHash };
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+})();

--- a/docs/cve-vault.css
+++ b/docs/cve-vault.css
@@ -6,4 +6,8 @@
 .cve-vault-row[aria-selected="true"],.cve-vault-row:focus-visible { border-color:var(--accent); outline:2px solid var(--accent-glow); color:var(--text-primary); }
 .cve-vault-detail { border-left:3px solid var(--accent); padding:0 1rem; line-height:1.55; }
 .cve-vault-status { color:var(--text-secondary); margin:.5rem 0 1rem; }
+.cve-vault-readiness { border-left:3px solid var(--text-muted); color:var(--text-secondary); padding-left:.65rem; }
+.cve-vault-readiness[data-state="ready"] { border-color:var(--brand); color:var(--brand); }
+.cve-vault-readiness[data-state="limited"] { border-color:#ffaa00; color:#ffcf66; }
+.cve-vault-readiness[data-state="offline"] { border-color:#ff6b6b; color:#ff8d8d; }
 @media (max-width:800px) { .cve-vault-controls,.cve-vault-layout { grid-template-columns:1fr; } .cve-vault-row { grid-template-columns:1fr 1fr; } }

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
     <title>T3MP3ST - Command & Control Dashboard</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="cve-vault.css" rel="stylesheet">
+    <script src="app-shell.js"></script>
     <script>
         // Apply the saved theme before first paint (no flash of default theme).
         try { var _t3mpTheme = localStorage.getItem('t3mp3st_theme'); if (_t3mpTheme && _t3mpTheme !== 'storm') document.documentElement.setAttribute('data-theme', _t3mpTheme); } catch (e) {}
@@ -3493,7 +3494,7 @@
                 <div class="nav-item" data-page="evidence">
                     <span class="icon">🔐</span> Evidence Vault
                 </div>
-                <div class="nav-item" data-page="cve-vault">
+                <div class="nav-item" data-page="cve-vault" data-shell-module="true">
                     <span class="icon">🛡️</span> CVE Vault
                 </div>
 
@@ -6053,6 +6054,7 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                     <div class="card" id="cveVaultApp" aria-labelledby="cveVaultTitle" aria-busy="false">
                         <div class="card-header"><h2 class="card-title" id="cveVaultTitle">CVE Vault</h2></div>
                         <p>Search CISA KEV with optional FIRST EPSS context. Matches are candidates, not proof that an observed version is vulnerable.</p>
+                        <p class="cve-vault-readiness" data-shell-readiness data-state="checking" role="status" aria-live="polite">Checking server readiness…</p>
                         <form class="cve-vault-controls">
                             <label>Vendor or product <input data-vault-query required maxlength="200" autocomplete="off" placeholder="e.g. Apache HTTP Server"></label>
                             <label>Filter <select data-vault-filter><option value="all">All</option><option value="epss">Has EPSS</option><option value="fresh">Current feeds</option><option value="stale">Stale feeds</option></select></label>
@@ -6162,7 +6164,9 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                         text.style.color = '#ffaa00';
                         text.textContent = 'Standalone Mode';
                     }
-                    return { status: 'standalone', message: 'Direct LLM mode — no API server needed' };
+                    const standalone = { status: 'standalone', message: 'Direct LLM mode — no API server needed' };
+                    window.T3MP3STShell.updateReadiness(standalone);
+                    return standalone;
                 }
 
                 try {
@@ -6200,6 +6204,7 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                         }
                     }
 
+                    window.T3MP3STShell.updateReadiness(data);
                     return data;
                 } catch (e) {
                     this.connected = false;
@@ -6218,7 +6223,9 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                             text.style.color = '#ffaa00';
                             text.textContent = 'Standalone Mode';
                         }
-                        return { status: 'standalone', message: 'Direct LLM mode — configure API URL in Settings to connect' };
+                        const standalone = { status: 'standalone', message: 'Direct LLM mode — configure API URL in Settings to connect' };
+                        window.T3MP3STShell.updateReadiness(standalone);
+                        return standalone;
                     }
 
                     // Update UI indicator
@@ -6230,7 +6237,9 @@ tempest.operators.<span class="function">spawn</span>(<span class="string">'scan
                         text.textContent = 'Offline';
                     }
 
-                    return { status: 'offline', error: e.message };
+                    const offline = { status: 'offline', error: e.message };
+                    window.T3MP3STShell.updateReadiness(offline);
+                    return offline;
                 }
             },
 
@@ -7682,21 +7691,9 @@ Correlating findings across agents, identifying patterns, producing actionable i
         }, 4000);
 
         // Navigation
-        function navigateTo(page) {
-            document.querySelectorAll('.nav-item').forEach(i => i.classList.toggle('active', i.dataset.page === page));
-            document.querySelectorAll('.page').forEach(p => p.classList.toggle('active', p.id === `page-${page}`));
-            const titles = { warroom: 'War Room', 'live-scan': 'Live Scan', receipts: 'Scope Receipts', operators: 'Operatives', evidence: 'Evidence Vault', 'cve-vault': 'CVE Vault', arsenal: 'Arsenal', terminal: 'Terminal', benchmarks: 'Benchmarks', configs: 'Config Library', 'ctf-range': 'CTF Range', general: 'Op Admiral', selfimprove: 'Self-Improvement', settings: 'Settings', about: 'About' };
-            document.getElementById('pageTitle').textContent = titles[page] || 'War Room';
-            document.getElementById('sidebar').classList.remove('open');
-            if (page === 'live-scan') setTimeout(() => window.refreshLiveScanPage?.(), 50);
-            if (page === 'receipts') setTimeout(() => window.refreshReceiptsPage?.(), 50);
-            if (page === 'operators' && typeof window.loadOperativesRoster === 'function') setTimeout(window.loadOperativesRoster, 80);
-            if (page === 'evidence' && typeof window.hydrateFindings === 'function') setTimeout(window.hydrateFindings, 60);
-            if (page === 'selfimprove' && typeof window.renderSelfImprove === 'function') setTimeout(window.renderSelfImprove, 60);
-            if (page === 'settings' && typeof window.uacInit === 'function') setTimeout(window.uacInit, 40);
+        function navigateTo(page, options) {
+            return window.T3MP3STShell.navigate(page, options);
         }
-
-        document.querySelectorAll('.nav-item').forEach(i => i.addEventListener('click', () => navigateTo(i.dataset.page)));
 
         function toggleSidebar() { document.getElementById('sidebar').classList.toggle('open'); }
 
@@ -22082,15 +22079,6 @@ Find and capture the flag. Show your methodology.`;
 
             toast('🗑️ CTF history cleared', 'warning');
         }
-
-        // Initialize CTF Range when navigating to the page
-        const originalNavigateTo = navigateTo;
-        navigateTo = function(page) {
-            originalNavigateTo(page);
-            if (page === 'ctf-range') {
-                initCtfRange();
-            }
-        };
 
         // ==================== SPECTRA - AI-POWERED RECONNAISSANCE ENGINE ====================
         /**

--- a/src/__tests__/app-shell.test.ts
+++ b/src/__tests__/app-shell.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const html = readFileSync('docs/index.html', 'utf8');
+const shell = readFileSync('docs/app-shell.js', 'utf8');
+const css = readFileSync('docs/cve-vault.css', 'utf8');
+
+class FakeClassList {
+  values = new Set<string>();
+  constructor(...initial: string[]) { initial.forEach(value => this.values.add(value)); }
+  toggle(value: string, force: boolean) { if (force) this.values.add(value); else this.values.delete(value); }
+  remove(value: string) { this.values.delete(value); }
+}
+
+class FakeElement {
+  classList: FakeClassList;
+  dataset: Record<string, string>;
+  id: string;
+  hidden = false;
+  tabIndex = -1;
+  textContent = '';
+  attributes = new Map<string, string>();
+  listeners = new Map<string, (event: { key?: string; preventDefault(): void }) => void>();
+  constructor(id: string, page?: string, active = false) {
+    this.id = id;
+    this.dataset = page ? { page } : {};
+    this.classList = new FakeClassList(...(active ? ['active'] : []));
+  }
+  setAttribute(name: string, value: string) { this.attributes.set(name, value); }
+  removeAttribute(name: string) { this.attributes.delete(name); }
+  addEventListener(name: string, listener: (event: { key?: string; preventDefault(): void }) => void) { this.listeners.set(name, listener); }
+}
+
+function shellHarness(hash: string) {
+  const navs = [new FakeElement('nav-warroom', 'warroom', true), new FakeElement('nav-cve', 'cve-vault')];
+  const pages = [new FakeElement('page-warroom'), new FakeElement('page-cve-vault')];
+  const title = new FakeElement('pageTitle');
+  const sidebar = new FakeElement('sidebar');
+  const readiness = new FakeElement('readiness');
+  const ids = new Map([...pages, title, sidebar].map(node => [node.id, node]));
+  const location = { hash };
+  const windowListeners = new Map<string, () => void>();
+  const document = {
+    readyState: 'complete',
+    getElementById: (id: string) => ids.get(id) || null,
+    querySelector: (selector: string) => selector === '.nav-item.active[data-page]' ? navs.find(nav => nav.classList.values.has('active')) || null : null,
+    querySelectorAll: (selector: string) => selector === '.page' ? pages : selector === '[data-shell-readiness]' ? [readiness] : navs,
+    addEventListener: () => undefined,
+    dispatchEvent: () => true,
+  };
+  const window = {
+    location,
+    history: {
+      pushState: (_state: null, _title: string, value: string) => { location.hash = value; },
+      replaceState: (_state: null, _title: string, value: string) => { location.hash = value; },
+    },
+    setTimeout: (callback: () => void) => callback(),
+    clearTimeout: () => undefined,
+    addEventListener: (name: string, listener: () => void) => windowListeners.set(name, listener),
+  };
+  class FakeCustomEvent { constructor(_name: string, _init: { detail: { page: string } }) {} }
+  const fetch = async () => { throw new Error('offline test harness'); };
+  class FakeAbortController { signal = {}; abort() {} }
+  vm.runInNewContext(shell, { window, document, CustomEvent: FakeCustomEvent, fetch, AbortController: FakeAbortController });
+  return { window, navs, pages, title, readiness };
+}
+
+describe('incremental application shell', () => {
+  it('loads one self-hosted shared shell and marks CVE Vault as the representative module', () => {
+    expect(html.match(/<script src="app-shell\.js"><\/script>/g)).toHaveLength(1);
+    expect(html).toContain('data-page="cve-vault" data-shell-module="true"');
+    expect(shell).toContain("'cve-vault': 'CVE Vault'");
+    expect(html).toContain('id="page-cve-vault"');
+    expect(html).toContain('<noscript>CVE Vault search requires JavaScript.');
+  });
+
+  it('parses as a classic external script and stays compatible with self-only script CSP', () => {
+    expect(() => new vm.Script(shell, { filename: 'docs/app-shell.js' })).not.toThrow();
+    expect(shell).not.toMatch(/\beval\s*\(|new Function|innerHTML|document\.write/);
+    const moduleStart = html.indexOf('<div class="page" id="page-cve-vault">');
+    const moduleEnd = html.indexOf('</main>', moduleStart);
+    expect(html.slice(moduleStart, moduleEnd)).not.toMatch(/\son[a-z]+=/i);
+  });
+
+  it('provides deterministic deep links and keyboard activation without trusting arbitrary hashes', () => {
+    expect(shell).toContain("var hash = '#/' + page");
+    expect(shell).toContain("event.key !== 'Enter' && event.key !== ' '");
+    expect(shell).toContain("if (!titles[page] || !document.getElementById('page-' + page)) return false");
+    expect(shell).toContain("window.addEventListener('hashchange'");
+    expect(shell).toContain("item.setAttribute('aria-current'");
+  });
+
+  it('activates a deep link and supports keyboard route changes', () => {
+    const harness = shellHarness('#/cve-vault');
+    expect(harness.pages[1].hidden).toBe(false);
+    expect(harness.pages[0].hidden).toBe(true);
+    expect(harness.title.textContent).toBe('CVE Vault');
+    expect(harness.navs[1].attributes.get('aria-current')).toBe('page');
+
+    let prevented = false;
+    harness.navs[0].listeners.get('keydown')?.({ key: 'Enter', preventDefault: () => { prevented = true; } });
+    expect(prevented).toBe(true);
+    expect(harness.window.location.hash).toBe('#/warroom');
+    expect(harness.pages[0].hidden).toBe(false);
+  });
+
+  it('rejects unknown hashes and renders server-authoritative readiness states', () => {
+    const harness = shellHarness('#/not-a-route');
+    expect(harness.title.textContent).toBe('War Room');
+    expect(harness.window.location.hash).toBe('#/not-a-route');
+    const shellApi = (harness.window as typeof harness.window & { T3MP3STShell: { updateReadiness(payload: object): void } }).T3MP3STShell;
+    shellApi.updateReadiness({ status: 'operational', llm: { connected: true } });
+    expect(harness.readiness.textContent).toBe('API and LLM ready (server verified)');
+    expect(harness.readiness.dataset.state).toBe('ready');
+  });
+
+  it('derives API and LLM readiness only from server health payloads', () => {
+    expect(shell).toContain("payload.status === 'operational'");
+    expect(shell).toContain('payload.llm && payload.llm.connected');
+    expect(shell).not.toMatch(/localStorage|sessionStorage|apiKey|secret/i);
+    expect(shell).toContain("fetch('/api/health'");
+    expect(html).toContain('data-shell-readiness');
+  });
+
+  it('keeps the representative visual and responsive contract stable', () => {
+    expect({
+      layout: css.includes('grid-template-columns:minmax(18rem,1fr) minmax(18rem,1fr)'),
+      responsive: css.includes('@media (max-width:800px)'),
+      focus: css.includes(':focus-visible'),
+      ready: css.includes('[data-state="ready"]'),
+      limited: css.includes('[data-state="limited"]'),
+      offline: css.includes('[data-state="offline"]'),
+    }).toEqual({ layout: true, responsive: true, focus: true, ready: true, limited: true, offline: true });
+  });
+});


### PR DESCRIPTION
Closes #182.

## Summary

- factor route activation, route lifecycle callbacks, hash deep links, keyboard navigation, and readiness rendering into one self-hosted application-shell asset
- migrate CVE Vault as the representative first module while retaining rendered no-JavaScript and error fallback content
- derive API/LLM readiness labels exclusively from the existing server `/api/health` response
- document the canonical source and one-module-at-a-time migration recipe for follow-up work

## Verification

- `npm run test:pr` — 86 files, 951 tests passed
- `COVERAGE_BASE=upstream/main PR_CHANGED_LINE_COVERAGE=50 npm run test:pr-coverage` — policy passed (0 changed executable TypeScript lines; shell JavaScript is exercised by VM behavior tests)
- `npm run docs:check` — passed
- `npm run verify-claims` — 27/27 passed
- `node --check docs/app-shell.js` — passed
- Chromium smoke: CVE Vault hash deep link and Enter-key navigation activate the correct visible page, update `aria-current`, and emit no page errors

## Security and trust assessment

The shell is a self-hosted classic script compatible with a `script-src 'self'` execution boundary and uses no `eval`, dynamic code construction, `innerHTML`, or remote executable content. It accepts only registered route names, renders readiness with `textContent`, and consumes only the existing same-origin health result. The change adds no API route, CORS override, Origin reflection, configuration metadata endpoint, credential persistence, or cwd `.env` loading.

Thanks @xxmafiaxxx for the original proposal and prior implementation in #163, which informed this focused change.
