### PR TITLE
chore(aiwg): preserve maintainer guidance artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ scripts/.export-denylist.local
 !.aiwg/plugins/**
 !.aiwg/bt6-maintainer.yaml
 !.aiwg/bt6-maintainer.lock.json
+!.aiwg/quickref.json
+!.aiwg/quickref.config.json
 
 server.pid
 

--- a/notes/guidance/upstream-pr-review-2026-07-10.md
+++ b/notes/guidance/upstream-pr-review-2026-07-10.md
@@ -1,0 +1,94 @@
+# Upstream PR Review - 2026-07-10
+
+<!-- markdownlint-disable MD013 -->
+
+Scope: `elder-plinius/T3MP3ST` open pull requests, reviewed as `jmagly`.
+
+Operating posture: supporting maintainer with contributor access. Keep activity to comments/reviews and local guidance unless explicitly authorized to merge, close, or mutate another contributor's branch.
+
+## Ready for Maintainer Merge Consideration
+
+These PRs have a `jmagly` approval signal or completion comment and currently show no merge conflict.
+
+| PR | Author | State | `jmagly` signal | Notes |
+| --- | --- | --- | --- | --- |
+| #71 | psigho | Mergeable, unstable | Formal review approved | UI live-agent count fix. No top-level comment, but approval review exists. |
+| #65 | madchap | Mergeable, unstable | Formal review approved | Target headers scope/rebase issue resolved. |
+| #64 | psigho | Mergeable, unstable | Formal review approved | OBSIDIVM backend routing fix. |
+| #63 | psigho | Mergeable, unstable | Formal review approved | War Room abort/decline reset fix. |
+| #59 | jmagly | Mergeable, unstable | Comment: approved | Own PR. |
+| #56 | shivamsingh-007 | Mergeable, unstable | Comment: approved | Portable War Room preflight command. |
+| #51 | sronaal | Mergeable, unstable | Comment: approved | Function calling / schema / Ollama work. |
+| #47 | opastorello | Mergeable, unstable | Comment: approved | Docker deployment support. |
+| #43 | Pazificateur69 | Mergeable, unstable | Comment: approved | Structured source/supply-chain scanner parsers. |
+| #42 | Pazificateur69 | Mergeable, unstable | Comment: approved | JSON scanner output parsing. |
+| #41 | Pazificateur69 | Mergeable, unstable | Comment: approved | Advertised tool-count test. |
+| #39 | Pazificateur69 | Mergeable, unstable | Comment: approved | Oracle-backed verify-claims gate. |
+| #29 | hummbl-dev | Mergeable, unstable | Formal review approved; later comment approved | Contribution receipt template. |
+| #22 | psigho | Mergeable, unstable | Comment: approved | Theme switcher/tour button UI fix. |
+| #18 | psigho | Mergeable, unstable | Comment: approved | Windows local-agent detection and Hermes auth path. |
+
+## Own Open PRs
+
+These are authored by `jmagly`. They are not missing contributor feedback; handle as own PRs/issues.
+
+| PR | State | Checks | Notes |
+| --- | --- | --- | --- |
+| #73 | Mergeable, clean | `test` success | No `jmagly` comment/review because it is an own PR. |
+| #70 | Mergeable, clean | `test` success | No `jmagly` comment/review because it is an own PR. |
+| #68 | Mergeable, clean | `test` success | No `jmagly` comment/review because it is an own PR. |
+| #59 | Mergeable, unstable | No check rollup reported | Own PR with approval comment. |
+
+## Blocked or Not Ready
+
+| PR | Author | State | Latest `jmagly` signal | Blocker |
+| --- | --- | --- | --- | --- |
+| #69 | seahop | Mergeable, unstable | Formal changes requested | `docs/RELEASE_CHECKLIST.md` deletion leaves README links broken. |
+| #48 | mseep-ai | Conflicting, dirty | Rebase requested | Needs rebase with main. |
+| #45 | RheagalFire | Conflicting, dirty | Rebase requested | Provider PR conflicts; sequence/rebase against provider changes. |
+| #44 | mahdi-salmanzade | Conflicting, dirty | Rebase requested | Needs rebase and scoped diff confirmation. |
+| #37 | Wibias | Mergeable, unstable | Formal changes requested | Remove extra blank line at EOF in `scripts/test-update.mjs`. |
+| #28 | mane | Mergeable, clean | Hardening gaps identified | Curl destination-override bypasses remain; not approved. |
+| #23 | mane | Conflicting, dirty | Rebase requested | Needs rebase with main. |
+| #10 | DMontgomery40 | Conflicting, dirty | Rebase requested | Likely superseded by main; still needs rebase/maintainer confirmation. |
+
+## Comment Coverage
+
+Contributor PRs with no top-level `jmagly` conversation comment: #71 only, but it has a formal `jmagly` approval review.
+
+Open PRs with no `jmagly` comment or review at all: #73, #70, #68. All three are authored by `jmagly`, so this is expected unless the maintainer wants an explicit self-triage note.
+
+No contributor-authored open PR was missing a `jmagly` comment or review signal as of this audit.
+
+## Local Verification Comments
+
+On 2026-07-10, each PR below was checked in a clean disposable worktree with:
+
+```bash
+npm ci
+npm run typecheck
+npm test
+```
+
+All three commands passed, and a verification comment was posted to each PR.
+
+| PR | Tested head | Verification comment |
+| --- | --- | --- |
+| #71 | `77b1655` | <https://github.com/elder-plinius/T3MP3ST/pull/71#issuecomment-4937642154> |
+| #65 | `664a6be` | <https://github.com/elder-plinius/T3MP3ST/pull/65#issuecomment-4937642292> |
+| #64 | `2f1fbd8` | <https://github.com/elder-plinius/T3MP3ST/pull/64#issuecomment-4937642461> |
+| #63 | `d43c405` | <https://github.com/elder-plinius/T3MP3ST/pull/63#issuecomment-4937642615> |
+| #59 | `d7da684` | <https://github.com/elder-plinius/T3MP3ST/pull/59#issuecomment-4937642756> |
+| #56 | `07e7df8` | <https://github.com/elder-plinius/T3MP3ST/pull/56#issuecomment-4937642979> |
+| #51 | `f6ea106` | <https://github.com/elder-plinius/T3MP3ST/pull/51#issuecomment-4937643119> |
+| #47 | `ef5c7c3` | <https://github.com/elder-plinius/T3MP3ST/pull/47#issuecomment-4937643299> |
+| #43 | `c20c24c` | <https://github.com/elder-plinius/T3MP3ST/pull/43#issuecomment-4937643464> |
+| #42 | `0c5c969` | <https://github.com/elder-plinius/T3MP3ST/pull/42#issuecomment-4937643614> |
+| #41 | `ce5f5b9` | <https://github.com/elder-plinius/T3MP3ST/pull/41#issuecomment-4937643724> |
+| #39 | `47fc8e9` | <https://github.com/elder-plinius/T3MP3ST/pull/39#issuecomment-4937643845> |
+| #29 | `6196052` | <https://github.com/elder-plinius/T3MP3ST/pull/29#issuecomment-4937644031> |
+| #22 | `c6253a9` | <https://github.com/elder-plinius/T3MP3ST/pull/22#issuecomment-4937644184> |
+| #18 | `bf50be9` | <https://github.com/elder-plinius/T3MP3ST/pull/18#issuecomment-4937644337> |
+| #73 | `9b524f0` | <https://github.com/elder-plinius/T3MP3ST/pull/73#issuecomment-4937644455> |
+| #70 | `df37e7c` | <https://github.com/elder-plinius/T3MP3ST/pull/70#issuecomment-4937644598> |
+| #68 | `0b2c4f5` | <https://github.com/elder-plinius/T3MP3ST/pull/68#issuecomment-4937644726> |


### PR DESCRIPTION
## Summary

Preserve a dated upstream pull-request review audit for future maintainer context and allow the canonical project quickref files to be tracked when generated.

## Linked issue

Closes #208

## Contribution receipt

- Scope class: docs_only
- Target authority: repository-local documentation and ignore rules
- Network use: none
- Claims or evidence changed: preserves the July 10 upstream PR verification audit
- Redaction/provenance notes: audit entries retain tested head SHAs and public GitHub verification-comment links

## Changes

- Add `notes/guidance/upstream-pr-review-2026-07-10.md` with reviewed PR readiness, blockers, and verification receipts.
- Allow `.aiwg/quickref.json` and `.aiwg/quickref.config.json` through the repository ignore rules so canonical quickrefs can be versioned when present.
- Bring the archival note into Markdown lint compliance without changing its recorded findings.

## Verification

- [x] `npm run typecheck`
- [x] `npm test` — 951 unit tests, 11 ops-preflight checks, and 19 model-matrix checks passed
- [x] `npm run doctor` — PASS with five optional-tool/offline-API warnings
- [x] Risk-specific checks: `npm exec markdownlint-cli2 -- notes/guidance/upstream-pr-review-2026-07-10.md`, `npm run lint`, and `npm run build`

## Risk and rollback

- Residual risk: low; the audit is explicitly dated and the ignore exceptions do not create files or alter runtime behavior.
- Rollback: revert this commit.

## Delivery checks

- [x] Diff is scoped against current `upstream/main`
- [x] No unrelated protected evidence, safety tests, or provider/config files were removed
- [x] Published review history was not force-pushed
- [x] Exact-head PR CI is green (including the 50% changed-line coverage floor)
- [x] I understand PR acceptance is not release certification