### PR TITLE
docs: mark v1.0.0 source certification checkpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # T3MP3ST Changelog
 
-## Unreleased — Source release readiness
+## 1.0.0 — 2026-09-08 — Certified source checkpoint
 
 - Release certification now includes deterministic contract suites, a required
   isolated local-server smoke run, and the documentation build. Dependency

--- a/docsite/t3mp3st-docs/content/CHANGELOG.md
+++ b/docsite/t3mp3st-docs/content/CHANGELOG.md
@@ -11,7 +11,7 @@ updated: "2026-07-20"
 ---
 # T3MP3ST Changelog
 
-## Unreleased — Source release readiness
+## 1.0.0 — 2026-09-08 — Certified source checkpoint
 
 - Release certification now includes deterministic contract suites, a required
   isolated local-server smoke run, and the documentation build. Dependency


### PR DESCRIPTION
Mark the existing source-release readiness changelog entry as v1.0.0, matching the package version, and synchronize its generated documentation copy.

The release is a certification checkpoint with only the tested source ZIP published. Release certification will rerun on the signed tag, including dependency audit, clean ZIP installation, and provenance verification.

Validation: full npm run test:release passed locally on Node 22.21.1 (988 tests, coverage, deterministic contracts, all four isolated smoke suites, documentation build, build and package dry run); npm audit reports zero vulnerabilities. Hosted PR gate also passed. This change modifies only the two changelog headings.
